### PR TITLE
Refactor paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ In Silesian language, a creature from our (Upper Silesians) demonology.
 - Partition schemes handling with GPT support (no CRC32 validation and no mirroring)
 - VFS (Virtual File System) Basics: Initial implementation of the Virtual File System, providing a unified interface for interacting with different file systems.
 - ext2 File System Support: Read-only support for ext2 file system, allowing access to files and directories in a read-only mode.
+- Enhanced paging: remapping and downmapping (e.g. 2MB->4KB) support
 
 # In progress
 - [ ] Ongoing refactoring and bug fixing

--- a/build.zig
+++ b/build.zig
@@ -129,10 +129,13 @@ fn addQemuRun(b: *Build, target: Build.ResolvedTarget, debug: bool, bios_path: [
             qemu.addArgs(&.{
                 //"-M", "q35", //for PCIe and NVMe support
                 "-M", "q35", //see qemu-system-x86_64 -M help
-                "-m", "2G", //Memory size
+                "-m", "800M", //Memory size
                 "-smp", "1", //one processor only
+                "-enable-kvm", //enable KVM for better performance
+                "-cpu", "host,-pdpe1gb,+pcid", //turn off 1GB pages due to not having downmapper for them yet
+                //"-cpu","qemu64,+pcid",
                 // "-cpu", "qemu64,+apic", // TODO: enable 1GB and 2MB pages, for now we turn them off
-                //"-enable-kvm", //to be able to use host cpu
+                //backup/"-enable-kvm", //to be able to use host cpu
                 //"-bios", bios_path, //we need ACPI >=2.0
                 // "-drive", "if=pflash,format=raw,readonly=on,file=/usr/share/ovmf/OVMF.fd",
             });
@@ -159,9 +162,9 @@ fn addQemuRun(b: *Build, target: Build.ResolvedTarget, debug: bool, bios_path: [
                 "d",
             }); //boot from cdrom
             qemu.addArgs(&.{ "-debugcon", "stdio" });
-            qemu.addArgs(&.{ "--trace", "events=.qemu-events" });
+            //TODO:uncomment this: qemu.addArgs(&.{ "--trace", "events=.qemu-events" });
             //qemu_iso_action.addArgs(&.{ "-d", "int,guest_errors,cpu_reset" });
-            qemu.addArgs(&.{ "-d", "guest_errors,cpu_reset" });
+            //TODO:uncomment this: qemu.addArgs(&.{ "-d", "guest_errors,cpu_reset" });
             //qemu_iso_action.addArgs(&.{ "-D", "qemu-logs.txt" });
             //qemu_iso_action.addArgs(&.{ "-display", "gtk", "-vga", "virtio" });
             qemu.addArgs(&.{ "-display", "gtk", "-vga", "std" });

--- a/build.zig
+++ b/build.zig
@@ -132,7 +132,7 @@ fn addQemuRun(b: *Build, target: Build.ResolvedTarget, debug: bool, bios_path: [
                 "-m", "800M", //Memory size
                 "-smp", "1", //one processor only
                 "-enable-kvm", //enable KVM for better performance
-                "-cpu", "host,-pdpe1gb,+pcid", //turn off 1GB pages due to not having downmapper for them yet
+                "-cpu", "host,-pdpe1gb,+pcid,+invpcid", //turn off 1GB pages due to not having downmapper for them yet
                 //"-cpu","qemu64,+pcid",
                 // "-cpu", "qemu64,+apic", // TODO: enable 1GB and 2MB pages, for now we turn them off
                 //backup/"-enable-kvm", //to be able to use host cpu

--- a/build.zig
+++ b/build.zig
@@ -129,13 +129,10 @@ fn addQemuRun(b: *Build, target: Build.ResolvedTarget, debug: bool, bios_path: [
             qemu.addArgs(&.{
                 //"-M", "q35", //for PCIe and NVMe support
                 "-M", "q35", //see qemu-system-x86_64 -M help
-                "-m", "800M", //Memory size
+                "-m", "30M", //Memory size
                 "-smp", "1", //one processor only
                 "-enable-kvm", //enable KVM for better performance
                 "-cpu", "host,-pdpe1gb,+pcid,+invpcid", //turn off 1GB pages due to not having downmapper for them yet
-                //"-cpu","qemu64,+pcid",
-                // "-cpu", "qemu64,+apic", // TODO: enable 1GB and 2MB pages, for now we turn them off
-                //backup/"-enable-kvm", //to be able to use host cpu
                 //"-bios", bios_path, //we need ACPI >=2.0
                 // "-drive", "if=pflash,format=raw,readonly=on,file=/usr/share/ovmf/OVMF.fd",
             });
@@ -163,9 +160,10 @@ fn addQemuRun(b: *Build, target: Build.ResolvedTarget, debug: bool, bios_path: [
             }); //boot from cdrom
             qemu.addArgs(&.{ "-debugcon", "stdio" });
             //TODO:uncomment this: qemu.addArgs(&.{ "--trace", "events=.qemu-events" });
-            //qemu_iso_action.addArgs(&.{ "-d", "int,guest_errors,cpu_reset" });
+            //qemu.addArgs(&.{ "-d", "int,guest_errors,cpu_reset" });
+            qemu.addArgs(&.{ "-d", "int,guest_errors,cpu_reset" });
             //TODO:uncomment this: qemu.addArgs(&.{ "-d", "guest_errors,cpu_reset" });
-            //qemu_iso_action.addArgs(&.{ "-D", "qemu-logs.txt" });
+            qemu.addArgs(&.{ "-D", "qemu-logs.txt" });
             //qemu_iso_action.addArgs(&.{ "-display", "gtk", "-vga", "virtio" });
             qemu.addArgs(&.{ "-display", "gtk", "-vga", "std" });
             if (debug) {
@@ -173,7 +171,7 @@ fn addQemuRun(b: *Build, target: Build.ResolvedTarget, debug: bool, bios_path: [
                     "-s",
                     "-S",
                 });
-                qemu.addArgs(&.{ "-d", "int" });
+                //qemu.addArgs(&.{ "-d", "int" });
             }
         },
         else => return error.UnsupportedArch,

--- a/src/bus/Pcie.zig
+++ b/src/bus/Pcie.zig
@@ -569,7 +569,7 @@ pub fn addMsixMessageTableEntry(msix_cap: MsixCap, bar: Bar, id: u11, vec_no: u8
     assert(msix_cap.mc.ts > id);
 
     const virt = switch (bar.address) {
-        inline else => |addr| paging.virtFromMME(addr),
+        inline else => |addr| paging.hhdmVirtFromPhys(addr),
     };
 
     const aligned_table_offset: u32 = msix_cap.to << 3;
@@ -577,7 +577,6 @@ pub fn addMsixMessageTableEntry(msix_cap: MsixCap, bar: Bar, id: u11, vec_no: u8
     const msi_x_te: *volatile MsixTableEntry = @ptrFromInt(virt + aligned_table_offset + id * @sizeOf(MsixTableEntry));
 
     msi_x_te.* = .{
-        //.msg_addr = paging.virtFromMME(@as(u32, @bitCast(Pcie.MsiMessageAddressRegister{
         //TODO Generealize it, now it's Intel specific
         .msg_addr = @as(u32, @bitCast(Pcie.MsiMessageAddressRegister{
             .destination_id = 0, //TODO promote to a parameter (CPUID)
@@ -604,24 +603,9 @@ pub fn addMsixMessageTableEntry(msix_cap: MsixCap, bar: Bar, id: u11, vec_no: u8
     //log.debug("MSI-X table entry added: {} @ {*}", .{ msi_x_te.*, msi_x_te });
 }
 
-// pub fn readMsixPendingBit(msix_cap: MsixCap, bar: BAR, id: u11) bool {
-//     const virt = switch (bar.address) {
-//         inline else => |addr| paging.virtFromMME(addr),
-//     };
-//     const aligned_pending_bit_offset: u32 = msix_cap.pbao << 3;
-//
-//     //pending bit array is an aray of bit values, e.g. id=9 means the 1st bit in the second byte
-//     const byte_no = id / 8;
-//     const bit_no: u3 = @intCast(id % 8);
-//
-//     //read the bit
-//     const pending_bit = @as(*const u8, @ptrFromInt(virt + aligned_pending_bit_offset + byte_no));
-//     return pending_bit.* & ((@as(u8, 1) << bit_no)) != 0;
-// }
-//
 pub fn readMsixPendingBitArrayBit(msix_cap: MsixCap, bar: Bar, msix_table_idx: u11) u1 {
     const virt = switch (bar.address) {
-        inline else => |addr| paging.virtFromMME(addr),
+        inline else => |addr| paging.hhdmVirtFromPhys(addr),
     };
     const aligned_pending_bit_offset: u32 = msix_cap.pbao << 3;
     // every bit under the PBA is a value of pending messgae in the Msix Table  (not interrupt vector number)
@@ -632,7 +616,7 @@ pub fn readMsixPendingBitArrayBit(msix_cap: MsixCap, bar: Bar, msix_table_idx: u
 
 pub fn writeMsixPendingBitArrayBit(msix_cap: MsixCap, bar: Bar, msix_table_idx: u11, value: u1) void {
     const virt = switch (bar.address) {
-        inline else => |addr| paging.virtFromMME(addr),
+        inline else => |addr| paging.hhdmVirtFromPhys(addr),
     };
     const aligned_pending_bit_offset: u32 = msix_cap.pbao << 3;
     // every bit under the PBA is a value of pending messgae in the Msix Table  (not interrupt vector number)

--- a/src/core/arch/x86_64/apic.zig
+++ b/src/core/arch/x86_64/apic.zig
@@ -12,8 +12,8 @@ var apic_default_base_phys: usize = undefined;
 var apic_default_base_virt: usize = undefined;
 const lvt_mask = 0x10000;
 
-fn isLapicSupported(cpuid: u16) bool {
-    const cpuid_res = cpu.cpuid(cpuid);
+fn isLapicSupported(eax_in: u16) bool {
+    const cpuid_res = cpu.Id.read(eax_in);
     return cpuid_res.edx & (1 << 9) != 0;
 }
 

--- a/src/core/arch/x86_64/apic.zig
+++ b/src/core/arch/x86_64/apic.zig
@@ -59,7 +59,7 @@ fn enableLapicWithDefaultBase() void {
 
     apic_default_base_phys = 0x0000_00FF_FFFF_F000 & apic_base_msr;
 
-    apic_default_base_virt = paging.virtFromMME(apic_default_base_phys);
+    apic_default_base_virt = paging.hhdmVirtFromPhys(apic_default_base_phys);
     log.info("APIC default base virtual address: 0x{x}", .{apic_default_base_virt});
 
     paging.adjustPageAreaPAT(apic_default_base_virt, apic_registry_size, .uncacheable) catch |err| {

--- a/src/core/arch/x86_64/gdt.zig
+++ b/src/core/arch/x86_64/gdt.zig
@@ -259,6 +259,4 @@ pub fn init() void {
     cpu.lgdt(&gdtd, @intFromEnum(segment_selector.kernel_code), @intFromEnum(segment_selector.kernel_data));
 
     log.info("GDT loaded", .{});
-
-    // Set the segment registers to the kernel code and data segments
 }

--- a/src/core/arch/x86_64/paging.zig
+++ b/src/core/arch/x86_64/paging.zig
@@ -641,7 +641,7 @@ fn recDownmapPageTables(comptime lvl: PageTableLevel, comptime tps: PageSize, al
                 //log.debug("Downmap phys.info.ps > tps", .{});
             }
         } else if (lvl != .l1) {
-            const next_rec_va = curr_va.shiftLeftIndexes(0);
+            const next_rec_va = curr_va.recursiveShiftLeftIndexes(0);
             try recDownmapPageTables(nextLevel(lvl), tps, allocator, next_rec_va, remapper_info);
         }
     }

--- a/src/core/arch/x86_64/paging.zig
+++ b/src/core/arch/x86_64/paging.zig
@@ -307,7 +307,7 @@ inline fn isLeaf(entry: anytype, comptime lvl: PageTableLevel) !bool {
     };
 }
 
-inline fn pageSizeFromLevel(lvl: PageTableLevel) PageSize {
+inline fn pageSizeFromLevel(comptime lvl: PageTableLevel) PageSize {
     return switch (lvl) {
         .l4 => unreachable,
         .l3 => .ps1g,

--- a/src/core/arch/x86_64/paging.zig
+++ b/src/core/arch/x86_64/paging.zig
@@ -605,7 +605,8 @@ pub fn downmapPageTables(comptime tps: PageSize, allocator: std.mem.Allocator) !
         .l4,
         tps,
         allocator,
-        VirtualAddress.fromUsize(RecInfo.l4TableVirt()),
+        //VirtualAddress.fromUsize(RecInfo.l4TableVirt()),
+        VirtualAddress.recursiveL4(),
         &remapper_info,
     );
 

--- a/src/core/arch/x86_64/paging.zig
+++ b/src/core/arch/x86_64/paging.zig
@@ -612,64 +612,6 @@ const RemapperInfo = struct {
     }
 };
 
-//TODO::tbd
-// pub fn downmapPageTables(comptime tps: PageSize, allocator: std.mem.Allocator) !void {
-//     comptime {
-//         if (tps == .ps1g) @compileError("Downmapping to 1GB page is not supported");
-//     }
-
-//     log.debug("Downmapping page tables to {any}", .{tps});
-//     defer log.debug("Downmapping page tables to {any} done", .{tps});
-
-//     var remapper_info: RemapperInfo = .{};
-//     // run with the recursive L4 page table address
-//     try downmapPageTablesRecursive(
-//         .l4,
-//         tps,
-//         allocator,
-//         VirtualAddress.recursiveL4(),
-//         &remapper_info,
-//     );
-
-//     log.debug("Downmapping info: {any}", .{remapper_info});
-// }
-
-//TODO::tbd
-// fn downmapPageTablesRecursive(comptime lvl: PageTableLevel, comptime tps: PageSize, allocator: std.mem.Allocator, rec_va: VirtualAddress, remapper_info: *RemapperInfo) !void {
-//     log.debug("\n\nDownmap::start lvl:{s} rec_va(0x{x}):{any}", .{ @tagName(lvl), rec_va.toUsize(), rec_va });
-
-//     //get page table slice
-//     const table = pageSliceFromVARecursive(lvl, rec_va);
-
-//     var i: u10 = 0; //must be u(9+1) to stop at 512
-//     while (i < entries_count) : (i += 1) {
-//         const entry_ptr = &table[i];
-//         const curr_va = rec_va.withDisp(i);
-
-//         if (!entry_ptr.present) continue;
-
-//         //log.debug("Downmap::entry[{d}] lvl:{s} -> entry[{d}]: {any} ", .{ i, @tagName(lvl), i, entry_ptr.* });
-
-//         if (try isLeaf(entry_ptr.*, lvl)) {
-//             //get physical address info
-//             //const phys_info = try physInfoFromVirt(curr_virt);
-
-//             const ps = pageSizeFromLevel(lvl);
-
-//             log.debug("Downmap::isLeaf lvl:{s} -> ps: {s} -> entry@{any}: {any}", .{ @tagName(lvl), @tagName(ps), curr_va, entry_ptr.* });
-
-//             remapper_info.inc(ps);
-//             // //downmap the page entry if it too big
-//             if (ps.gt(tps)) {
-//                 //log.debug("Downmap phys.info.ps > tps", .{});
-//             }
-//         } else if (lvl != .l1) {
-//             const next_rec_va = curr_va.recursiveShiftLeftIndexes(0);
-//             try downmapPageTablesRecursive(nextLevel(lvl), tps, allocator, next_rec_va, remapper_info);
-//         }
-//     }
-// }
-
 pub fn downmapPageTables(comptime tps: PageSize, allocator: std.mem.Allocator) !void {
     comptime {
         if (tps == .ps1g) @compileError("Downmapping to 1GB page is not supported");
@@ -689,9 +631,6 @@ pub fn downmapPageTables(comptime tps: PageSize, allocator: std.mem.Allocator) !
     new_l4[default_recursive_index].aligned_address_4kbytes = @truncate(new_l4_phys >> 12);
 
     // set l4_table address in CR3
-    // TODO:
-
-    // Flush the TLB
     // TODO:
 
     log.debug("Downmapping info: {any}", .{remapper_info});

--- a/src/core/arch/x86_64/paging.zig
+++ b/src/core/arch/x86_64/paging.zig
@@ -474,8 +474,8 @@ pub inline fn idxFromVirt(virt: usize, lvl: PageTableLevel) usize {
 }
 
 /// Next level of the page table
-fn nextLevel(level: PageTableLevel) PageTableLevel {
-    return switch (level) {
+fn nextLevel(comptime lvl: PageTableLevel) PageTableLevel {
+    return switch (lvl) {
         .l4 => .l3,
         .l3 => .l2,
         .l2 => .l1,
@@ -501,16 +501,16 @@ fn pageSliceFromVA(comptime lvl: PageTableLevel, va: VirtualAddress) switch (lvl
 } {
     switch (lvl) {
         .l4 => {
-            return @as(*L4Table, @ptrFromInt(VirtualAddress.recursiveL4().toUsize()))[0..entries_count];
+            return VirtualAddress.recursiveL4().asPtr(*L4Table)[0..entries_count];
         },
         .l3 => {
-            return @as(*L3Table, @ptrFromInt(VirtualAddress.recursiveL3(va.l4idx).toUsize()))[0..entries_count];
+            return VirtualAddress.recursiveL3(va.l4idx).asPtr(*L3Table)[0..entries_count];
         },
         .l2 => {
-            return @as(*L2Table, @ptrFromInt(VirtualAddress.recursiveL2(va.l4idx, va.l3idx).toUsize()))[0..entries_count];
+            return VirtualAddress.recursiveL2(va.l4idx, va.l3idx).asPtr(*L2Table)[0..entries_count];
         },
         .l1 => {
-            return @as(*L1Table, @ptrFromInt(VirtualAddress.recursiveL1(va.l4idx, va.l3idx, va.l2idx).toUsize()))[0..entries_count];
+            return VirtualAddress.recursiveL1(va.l4idx, va.l3idx, va.l2idx).asPtr(*L1Table)[0..entries_count];
         },
     }
 }

--- a/src/core/arch/x86_64/paging.zig
+++ b/src/core/arch/x86_64/paging.zig
@@ -616,12 +616,7 @@ const RemapperInfo = struct {
 
 /// Downmaps the page tables to a smaller page size. Currently supports only 4KB.
 pub fn downmapPageTables(comptime tps: PageSize, allocator: std.mem.Allocator) !void {
-    comptime {
-        switch (tps) {
-            .ps1g, .ps2m => {},
-            else => @compileError("Unsupported page size for downmapping: " ++ @tagName(tps)),
-        }
-    }
+    comptime if (tps.gt(.ps4k)) @compileError("Unsupported page size for downmapping: " ++ @tagName(tps));
 
     log.debug("Downmapping page tables to {any}", .{tps});
     defer log.debug("Downmapping page tables to {any} done", .{tps});

--- a/src/core/arch/x86_64/paging.zig
+++ b/src/core/arch/x86_64/paging.zig
@@ -306,6 +306,15 @@ fn isLeaf(entry: anytype, comptime lvl: PageTableLevel) !bool {
     };
 }
 
+fn pageSizeFromFromLevel(lvl: PageTableLevel) PageSize {
+    return switch (lvl) {
+        .l4 => unreachable,
+        .l3 => .ps1g,
+        .l2 => .ps2m,
+        .l1 => .ps4k,
+    };
+}
+
 // fn getPhysBase(entry: anytype, comptime is_leaf: bool, comptime lvl: PageTableLevel) usize {
 //     return switch (lvl) {
 //         .l4 => @as(usize, entry.aligned_address_4kbytes) << 12,
@@ -402,7 +411,7 @@ pub inline fn buildIndex(virt: usize) Index {
     };
 }
 
-///Use if there is no need to get the whole Index
+/// Use this if there is no need to get the whole Index
 pub inline fn idxFromVirt(virt: usize, lvl: PageTableLevel) usize {
     const shift_amount = 12 + (@intFromEnum(lvl) - 1) * 9;
     return (virt >> shift_amount) & 0x1FF;
@@ -460,7 +469,7 @@ pub fn physInfoFromVirt(virt: usize) !PhysInfo {
             const entry = curr_table[idx];
             if (!entry.present) return error.PageFault;
 
-            if (try isLeaf(entry, lvl)) return .{ .phys_base = entry.getPhysBase(), .phys = physFromIndex(entry, pidx, lvl), .lvl = lvl, .ps = .ps4k }; //TODO: get the right data
+            if (try isLeaf(entry, lvl)) return .{ .phys_base = entry.getPhysBase(), .phys = physFromIndex(entry, pidx, lvl), .lvl = lvl, .ps = pageSizeFromFromLevel(lvl) };
         } else break;
     }
 

--- a/src/core/arch/x86_64/paging.zig
+++ b/src/core/arch/x86_64/paging.zig
@@ -663,6 +663,8 @@ fn recDownmapPageTables(comptime lvl: PageTableLevel, comptime tps: PageSize, al
 fn getLowestEntryFromVirt(virt: usize) !GenEntryInfo {
     const va = VirtualAddress.fromUsize(virt);
     var res: GenEntryInfo = .{};
+    log.debug("getLowestEntryFromVirt start: virt:0x{x} va:{any}", .{ virt, va });
+    defer log.debug("getLowestEntryFromVirt done: virt:0x{x} va:{any} -> res: {any}", .{ virt, va, res });
 
     inline for (page_table_levels) |lvl| {
         const curr_table = pageSliceFromVA(lvl, va);

--- a/src/core/arch/x86_64/paging.zig
+++ b/src/core/arch/x86_64/paging.zig
@@ -24,6 +24,830 @@ const limine = @import("limine");
 const cpu = @import("./cpu.zig");
 
 const log = std.log.scoped(.paging);
+
+const PageSize = enum(u32) { ps4k = 0x1000, ps2m = 0x200000, ps1g = 0x40000000 };
+
+const PagingMode = enum(u1) {
+    four_level = 0,
+    five_level = 1,
+};
+
+const PageTableLevel = enum(u3) {
+    l4 = 4, //pml4
+    l3 = 3, //pdpt
+    l2 = 2, //pd
+    l1 = 1, //pt
+};
+
+//constants
+pub const default_page_size: PageSize = @enumFromInt(config.mem_page_size);
+const entries_count: usize = 512;
+const default_recursive_index: u9 = 510; //0x1FE
+const RecInfo = RecursiveInfo(default_recursive_index); //0x776
+const page_table_levels = [_]PageTableLevel{ .l4, .l3, .l2, .l1 };
+
+//variables
+pub export var hhdm_request: limine.HhdmRequest = .{};
+pub export var paging_mode_request: limine.PagingModeRequest = .{ .mode = .four_level, .flags = 0 }; //default L4 paging
+var hhdm_offset: usize = undefined;
+
+//types
+const RawEntry = u64;
+///Info on physical address placement in the page table
+const PhysInfo = struct { phys: usize, lvl: PageTableLevel, ps: PageSize };
+
+fn RecursiveInfo(comptime recursive_index: u9) type {
+    return struct {
+        const rec_idx: usize = recursive_index; //510
+        const sign = 0o177777 << 48; //sign extension (always 1 for second half of the memory space)
+
+        // retrieve the page table indices of the address that we want to translate
+        pub inline fn pml4TableAddr() usize {
+            return sign | (rec_idx << 39) | (rec_idx << 30) | (rec_idx << 21) | (rec_idx << 12);
+        }
+        pub inline fn pdptTablAddr(pml4_idx: usize) usize {
+            return sign | (rec_idx << 39) | (rec_idx << 30) | (rec_idx << 21) | (pml4_idx << 12);
+        }
+        pub inline fn pdTableAddr(pml4_idx: usize, pdpt_idx: usize) usize {
+            return sign | (rec_idx << 39) | (rec_idx << 30) | (pml4_idx << 21) | (pdpt_idx << 12);
+        }
+        pub inline fn ptTableAddr(pml4_idx: usize, pdpt_idx: usize, pd_idx: usize) usize {
+            return sign | (rec_idx << 39) | (pml4_idx << 30) | (pdpt_idx << 21) | (pd_idx << 12);
+        }
+    };
+}
+
+// the lowest level entry stoing the frame address
+fn PageLeafEntry(comptime ps: PageSize) type {
+    return switch (ps) {
+        .ps4k => L1Entry,
+        .ps2m => L2Entry2M,
+        .ps1g => L3Entry1G,
+    };
+}
+
+pub const GenericEntryInfo = struct {
+    entry_ptr: ?*RawEntry,
+    lvl: PageTableLevel,
+    ps: PageSize,
+};
+
+// TODO: usngnamespace does not work in case of the fields
+pub fn GenPageEntry(comptime ps: PageSize, comptime lvl: PageTableLevel) type {
+    //return packed struct(GenericEntry) {
+    return switch (lvl) {
+        .l4 => packed struct(RawEntry) {
+            const Self = @This();
+            present: bool = false, //0
+            writable: bool = false, //1
+            user: bool = false, //2
+            write_through: bool = false, //3
+            cache_disabled: bool = false, //4
+            accessed: bool = false, //5
+            dirty: bool = false, //6
+            rsrvd_a: u1 = 0, //7
+            ignrd_a: u3 = 0, //8-10
+            restart: u1 = 0, //11
+            aligned_address_4kbytes: u39, //12-50- PML3 address
+            rsrvd_b: u1 = 0, //51
+            ignrd_b: u11 = 0, //52-62
+            execute_disable: bool = false, //63
+
+            pub fn retrieveTable(self: Self) ?[]L3Entry {
+                return if (self.present) @as(*L3Table, @ptrFromInt(hhdmVirtFromPhys(self.aligned_address_4kbytes << @bitSizeOf(u12)))) else null;
+            }
+        },
+        // .pdpte1gbytes
+        .l3 => switch (ps) {
+            .ps1g => packed struct(RawEntry) {
+                const Self = @This();
+                present: bool, //0
+                writable: bool, //1
+                user: bool, //2
+                write_through: bool, //3
+                cache_disabled: bool, //4
+                accessed: bool, //5
+                dirty: bool, //6
+                huge: bool, //7
+                global: bool, //8
+                ignrd_a: u2, //9-10
+                restart: u1, //11
+                pat: u1, //12
+                rsrvd_a: u17, //13-29
+                aligned_address_1gbytes: u21, //30-50
+                rsrvd_b: u1, //51 //must be 0
+                ignrd_b: u7, //52-58
+                protection_key: u4, //59-62
+                execute_disable: bool, //63
+
+                pub inline fn retrieveFrameVirt(self: Self) ?usize {
+                    return if (self.present) self.aligned_address_1gbytes else null;
+                }
+
+                pub inline fn retrieveFrame(self: Self) ?[]usize {
+                    return if (self.present) @as(*[.ps1g]RawEntry, @ptrFromInt(self.retrieveFrameVirt().?)) else null;
+                }
+            },
+            .ps4k, .ps2m => packed struct(RawEntry) {
+                const Self = @This();
+                present: bool = false, //0
+                writable: bool = false, //1
+                user: bool = false, //2
+                write_through: bool = false, //3
+                cache_disabled: bool = false, //4
+                accessed: bool = false, //5
+                ignrd_a: u1 = 0, //6
+                hudge: bool = false, //7
+                ignrd_b: u3 = 0, //8-10
+                restart: u1 = 0, //11
+                aligned_address_4kbytes: u39, //12-50
+                rsrvd_a: u1 = 0, //50
+                ignr_b: u11 = 0, //52-62
+                execute_disable: bool = false, //63
+
+                pub inline fn retrieveTable(self: Self) ?[]L2Entry {
+                    return if (self.present) @as(*L2Table, @ptrFromInt(hhdmVirtFromPhys(self.aligned_address_4kbytes << @bitSizeOf(u12)))) else null;
+                }
+            },
+            //            else => @compileError("Unsupported page size:" ++ @tagName(ps)),
+        },
+        .l2 => switch (ps) {
+            .ps2m => packed struct(RawEntry) {
+                const Self = @This();
+                present: bool = false, //0
+                writable: bool = false, //1
+                user: bool = false, //2
+                write_through: bool = false, //3
+                cache_disabled: bool = false, //4
+                accessed: bool = false, //5
+                dirty: bool = false, //6
+                hudge: bool = false, //7
+                global: bool = false, //8
+                ignrd_a: u2 = 0, //9-10
+                restart: u1 = 0, //11
+                pat: u1 = 0, //12
+                rsrvd_a: u8 = 0, //13-20
+                aligned_address_2mbytes: u30, //21-50
+                rsrvd_b: u1 = 0, //51
+                ignrd_b: u7 = 0, //52-58
+                protection_key: u4 = 0, //59-62
+                execute_disable: bool = false, //63
+
+                pub inline fn retrieveFrameVirt(self: Self) ?usize {
+                    return if (self.present) self.aligned_address_2mbytes else null;
+                }
+
+                pub inline fn retrievFrame(self: Self) ?[]usize {
+                    return if (self.present) @as(*[.ps2m]usize, @ptrFromInt(self.retrieveFrameVirt().?)) else null;
+                }
+            },
+            .ps4k => packed struct(RawEntry) {
+                const Self = @This();
+                present: bool = false, //0
+                writable: bool = false, //1
+                user: bool = false, //2
+                write_through: bool = false, //3
+                cache_disabled: bool = false, //4
+                accessed: bool = false, //5
+                ignrd_a: bool = false, //6
+                hudge: bool = false, //7 //must be 0
+                ignrd_b: u3 = 0, //8-10
+                restart: u1 = 0, //11
+                aligned_address_4kbytes: u39, //12-50
+                rsrvd_a: u1 = 0, //51-51 //must be 0
+                ignrd_c: u11 = 0, //52-62
+                execute_disable: bool = true, //63
+                pub inline fn retrieveTable(self: Self) ?[]L1Entry {
+                    return if (self.present) @as(*L1Table, @ptrFromInt(hhdmVirtFromPhys(self.aligned_address_4kbytes << @bitSizeOf(u12)))) else null;
+                }
+            },
+            else => @compileError("Unsupported page size:" ++ ps),
+        },
+        .l1 => packed struct(RawEntry) {
+            const Self = @This();
+            present: bool = false, //0
+            writable: bool = false, //1
+            user: bool = false, //2
+            write_through: bool = false, //3
+            cache_disabled: bool = false, //4
+            accessed: bool = false, //5
+            dirty: bool = false, //6
+            pat: u1 = 0, //7
+            global: bool = false, //8
+            ignrd_a: u2 = 0, //9-10
+            restart: u1 = 0, //11
+            aligned_address_4kbytes: u39, //12-50
+            rsrvd_a: u1 = 0, //51-51 //must be 0
+            ignrd_b: u7 = 0, //52-58
+            protection_key: u4 = 0, //5 w9-62
+            execute_disable: bool = false, //63
+
+            pub inline fn retrieveFrameVirt(self: Self) ?usize {
+                return if (self.present) self.aligned_address_4kbytes else null;
+            }
+
+            pub inline fn retrieveFrame(self: Self) ?[]usize {
+                return if (self.present) @as(*[@intFromEnum(PageSize.ps4k)]RawEntry, @ptrFromInt(self.retrieveFrameVirt().?)) else null;
+            }
+        },
+    };
+}
+
+pub const L4Entry = GenPageEntry(default_page_size, .l1);
+pub const L3Entry = GenPageEntry(default_page_size, .l3);
+pub const L3Entry1G = GenPageEntry(.ps1g, .l3);
+pub const L2Entry = GenPageEntry(default_page_size, .l2);
+pub const L2Entry2M = GenPageEntry(.ps2m, .l2);
+pub const L1Entry = GenPageEntry(default_page_size, .l1);
+pub const L4Table = [entries_count]L4Entry;
+pub const L3Table = [entries_count]L3Entry;
+pub const L2Table = [entries_count]L2Entry;
+pub const L1Table = [entries_count]L1Entry;
+
+/// Holds indexes of all paging tables
+/// each table holds indexes of 512 entries, so we need only 9 bytes to store index
+/// Offset is 12 bits to address 4KiB page
+const Index = struct {
+    const Self = @This();
+    sign: u1, //sign extension
+    l4_idx: u9, //pml4
+    l3_idx: u9, //pdpt
+    l2_idx: u9, //pd //for 1GB and 2MB pages is higher part of the index
+    l1_idx: u9, //pt // for 1GB pages is a high part of the index
+    offset: u12, //12 bites for 4k pages, 21 for 2m pages, 30 for 1g pages
+
+    pub inline fn yieldOffset(self: Self, comptime page_size: PageSize) switch (page_size) {
+        .ps4k => u12,
+        .ps2m => u21,
+        .ps1g => u30,
+    } {
+        return switch (page_size) {
+            .ps4k => self.offset,
+            .ps2m => (@as(u21, self.l1_idx) << 12) + self.offset,
+            .ps1g => (@as(u30, self.l2_idx) << 21) + (@as(u21, self.l1_idx) << 12) + self.offset,
+        };
+    }
+
+    pub inline fn idxFromLvl(self: Self, comptime lvl: PageTableLevel) usize {
+        return switch (lvl) {
+            .l4 => self.l4_idx,
+            .l3 => self.l3_idx,
+            .l2 => self.l2_idx,
+            .l1 => self.l1_idx,
+        };
+    }
+};
+
+/// Get paging indexes from virtual address
+/// It maps 48-bit virtual address to 9-bit indexes of all 52 physical address bits
+/// src osdev: "Virtual addresses in 64-bit mode must be canonical, that is,
+/// the upper bits of the address must either be all 0s or all 1s.
+// For systems supporting 48-bit virtual address spaces, the upper 16 bits must be the same"
+pub inline fn buildIndex(virt: usize) Index {
+    return .{
+        .sign = @truncate(virt >> 47), //sign extension
+        .l4_idx = @truncate(virt >> 39), //47->39
+        .l3_idx = @truncate(virt >> 30), //39->30
+        .l2_idx = @truncate(virt >> 21), //30->21
+        .l1_idx = @truncate(virt >> 12), //21->12
+        .offset = @truncate(virt), //12 bites
+    };
+}
+
+///Use if there is no need to get the whole Index
+pub inline fn idxFromVirt(virt: usize, lvl: PageTableLevel) usize {
+    const shift_amount = 12 + (@intFromEnum(lvl) - 1) * 9;
+    return (virt >> shift_amount) & 0x1FF;
+}
+
+/// Get virtual address from paging indexes
+pub inline fn virtFromIndex(pidx: Index) usize {
+    const addr = (@as(usize, pidx.l4_idx) << 39) | (@as(usize, pidx.l3_idx) << 30) | (@as(usize, pidx.l2_idx) << 21) | @as(usize, pidx.l1_idx) << 12 | pidx.offset;
+    switch (pidx.sign) {
+        0 => return addr & 0x7FFF_FFFF_FFFF,
+        1 => return addr | 0xFFFF_8000_0000_0000,
+        else => @panic("Invalid address"),
+    }
+}
+
+fn pageSliceFromIndex(comptime lvl: PageTableLevel, pidx: Index) switch (lvl) {
+    .l4 => ?[]L4Entry,
+    .l3 => ?[]L3Entry,
+    .l2 => ?[]L2Entry,
+    .l1 => ?[]L1Entry,
+} {
+    switch (lvl) {
+        .l4 => {
+            return @as(*L4Table, @ptrFromInt(RecInfo.pml4TableAddr()))[0..entries_count];
+        },
+        .l3 => {
+            return @as(*L3Table, @ptrFromInt(RecInfo.pdptTablAddr(pidx.l4_idx)))[0..entries_count];
+        },
+        .l2 => {
+            return @as(*L2Table, @ptrFromInt(RecInfo.pdTableAddr(pidx.l4_idx, pidx.l3_idx)))[0..entries_count];
+        },
+        .l1 => {
+            return @as(*L1Table, @ptrFromInt(RecInfo.ptTableAddr(pidx.l4_idx, pidx.l3_idx, pidx.l2_idx)))[0..entries_count];
+        },
+    }
+}
+
+fn pageSliceFromVirt(comptime lvl: PageTableLevel, virt: usize) switch (lvl) {
+    .l4 => ?[]L4Entry,
+    .l3 => ?[]L3Entry,
+    .l2 => ?[]L2Entry,
+    .l1 => ?[]L1Entry,
+} {
+    const pidx = buildIndex(virt);
+    return pageSliceFromIndex(lvl, pidx);
+}
+
+pub fn physInfoFromVirt(virt: usize) !PhysInfo {
+    log.debug("physInfoFromVirt starting...", .{});
+    defer log.debug("physInfoFromVirt finished.", .{});
+
+    const pidx = buildIndex(virt);
+    var curr_table = pageSliceFromIndex(.l4, pidx);
+
+    _ = &curr_table; //TODO remove this line
+
+    inline for (page_table_levels) |lvl| {
+        const idx = pidx.idxFromLvl(lvl);
+        const entry = curr_table[idx]; //TODO: different table type for each level, make it inline
+
+        if (!entry.present) return error.PageFault;
+
+        return .{ .phys = 0, .lvl = lvl, .ps = entry.ps };
+    }
+
+    unreachable;
+}
+
+// Recursive get physical address from virtual address
+// TODO: refactor
+pub fn recPhysFromVirtInfo(virt: usize) !struct { phys: usize, lvl: PageTableLevel, ps: PageSize } {
+    const pidx = buildIndex(virt);
+
+    // check if pml4 entry is present
+    const pml4e = @as(*L4Table, @ptrFromInt(RecInfo.pml4TableAddr()))[pidx.l4_idx];
+    if (!pml4e.present) return error.PageFault;
+
+    // check if pdpt entry is present
+    const pdpte = @as(*L3Table, @ptrFromInt(RecInfo.pdptTablAddr(pidx.l4_idx)))[pidx.l3_idx];
+    if (!pdpte.present) return error.PageFault;
+
+    if (pdpte.hudge) {
+        return .{ .phys = (@as(GenPageEntry(.ps1g, .l3), @bitCast(pdpte)).retrieveFrameVirt().? << @bitSizeOf(u30)) + pidx.yieldOffset(.ps1g), .lvl = .l3, .ps = .ps1g };
+    }
+
+    // check if pd entry is present
+    const pde = @as(*L2Table, @ptrFromInt(RecInfo.pdTableAddr(pidx.l4_idx, pidx.l3_idx)))[pidx.l2_idx];
+    if (!pde.present) return error.PageFault;
+
+    if (pde.hudge) {
+        return .{ .phys = (@as(GenPageEntry(.ps2m, .l2), @bitCast(pde)).retrieveFrameVirt().? << @bitSizeOf(u21)) + pidx.yieldOffset(.ps2m), .lvl = .l2, .ps = .ps2m };
+    }
+
+    // check if pt entry is present
+    const pte = @as(*L1Table, @ptrFromInt(RecInfo.ptTableAddr(pidx.l4_idx, pidx.l3_idx, pidx.l2_idx)))[pidx.l1_idx];
+    if (!pte.present) return error.PageFault;
+
+    return .{ .phys = (@as(GenPageEntry(.ps4k, .l1), pte).retrieveFrameVirt().? << @bitSizeOf(u12)) + pidx.yieldOffset(.ps4k), .lvl = .l1, .ps = .ps4k };
+}
+
+///////
+
+pub inline fn recPhysFromVirt(virt: usize) !usize {
+    const info = try recPhysFromVirtInfo(virt);
+    return info.phys;
+}
+
+/// Limine bootloader allocates mixed size pages in reclaimable memory; We need to remap them into
+/// requestaded size pages. tps is the requested page size and lvl is the level of the page table to handle.
+/// We could upgrade the page size e.g. from 4K, 2M to 1G, or downgrade from 1G to 2M or 4K.
+// fn recRemapPageTables(comptime lvl: Level, comptime tps: PageSize, allocator: std.mem.Allocator, virt: usize) !usize {
+//     //_ = lvl;
+//     _ = tps;
+//     //_ = allocator;
+//     //@compileError("Not implemented");
+
+//     const pidx = buildIndex(virt);
+
+//     switch (lvl) {
+//         .pml4 => {
+//             std.debug.assert(pidx.pml4_idx == default_recursive_index and pidx.pdpt_idx == default_recursive_index and pidx.pd_idx_or_high_offset == default_recursive_index and pidx.pt_idx_or_high_offset == default_recursive_index);
+
+//             var new_pml4t: []Pml4e = undefined;
+//             if (pidx.offset == 0) new_pml4t = try dupePageStructTable(Pml4e, allocator, @as([*]Pml4e, @ptrFromInt(virt))[0..entries_count]);
+
+//             for (0..entries_count) |i| {
+//                 const new_pml4e = &@as(*Pml4, @ptrFromInt(RecInfo.pml4TableAddr()))[i];
+//                 if (!new_pml4e.present) continue;
+
+//                 log.debug("remap virt[{d}]: 0x{x} == 0x{x} pml4.pidx: {any}, pml4e: {any}, pml4e: {*}, aligned_adress_4kb=0x{x}", .{ i, virt, virtFromIndex(pidx), pidx, new_pml4e, new_pml4t.ptr, new_pml4e.aligned_address_4kbytes << 12 });
+
+//                 const pdpt_virt = recRemapPageTables(.pdpt, tps, allocator, virt + i) catch return error.PageFault;
+//                 const pdpt_phys = recPhysFromVirt(pdpt_virt);
+//                 new_pml4e.aligned_address_4kbytes = @as(u39, pdpt_phys >> 12);
+//             }
+//             return @intFromPtr(new_pml4t);
+//         },
+//         .pdpt => {
+//             //const pdpte = @as(*Pdpt, @ptrFromInt(RecInfo.pdptTablAddr(0)))[0..entries_count];
+//             //dupePageStructTable(allocator, pdpte) catch return error.PageFault;
+
+//             log.debug("remap virt: 0x{x} pdpt.pidx: {any}", .{ virtFromIndex(pidx), pidx });
+//         },
+//         .pd => {
+//             //const pde = @as(*Pd, @ptrFromInt(RecInfo.pdTableAddr(0, 0)))[0..entries_count];
+//             //dupePageStructTable(allocator, pde) catch return error.PageFault;
+//             log.debug("remap pd.pidx: {any}", .{pidx});
+//         },
+//         .pt => {
+//             //const pte = @as(*Pt, @ptrFromInt(RecInfo.ptTableAddr(0, 0, 0)))[0..entries_count];
+//             //dupePageStructTable(allocator, pte) catch return error.PageFault;
+//             log.debug("remap pt.pidx: {any}", .{pidx});
+//         },
+//     }
+// }
+
+// pub fn remapPageTables(comptime tps: PageSize, allocator: std.mem.Allocator) !void {
+//     // build index from the virtual address of the pml4 table
+//     const pidx = buildIndex(RecInfo.pml4TableAddr());
+//     return recRemapPageTables(.pml4, tps, allocator, virtFromIndex(pidx)) catch return error.PageFault;
+// }
+
+// fn dupePageStructTable(comptime T: type, allocator: std.mem.Allocator, src: []T) ![]T {
+//     // no matter what page size we need to allocate 4kbytes aligned page, but if you use for instance Arena Allocator, then
+//     // we do not controll the alignment, so it is better to aligned imperatively
+//     const dst = allocator.allocWithOptions(T, entries_count, @intFromEnum(PageSize.ps4k), null) catch |err| {
+//         log.err("Failed to allocate page table: {any}", .{err});
+//         return error.PageFault;
+//     };
+//     @memcpy(dst.ptr, src);
+//     return dst;
+// }
+
+pub fn recLowestEntryFromVirtInfo(virt: usize) !GenericEntryInfo {
+    const pidx = buildIndex(virt);
+
+    var res: GenericEntryInfo = .{ .entry_ptr = null, .lvl = .l4, .ps = .ps4k };
+
+    // check if pml4 entry is present
+    const pml4e = &@as(*L4Table, @ptrFromInt(RecInfo.pml4TableAddr()))[pidx.l4_idx];
+    if (!pml4e.present) return error.PageFault;
+
+    res = .{ .entry_ptr = @ptrCast(pml4e), .lvl = .l4, .ps = .ps4k };
+
+    // check if pdpt entry is present
+    const pdpte = &@as(*L3Table, @ptrFromInt(RecInfo.pdptTablAddr(pidx.l4_idx)))[pidx.l3_idx];
+
+    if (!pdpte.present) return res;
+
+    if (pdpte.hudge) {
+        return .{ .entry_ptr = @ptrCast(pdpte), .lvl = .l3, .ps = .ps1g };
+    }
+
+    res = .{ .entry_ptr = @ptrCast(pdpte), .lvl = .l3, .ps = .ps2m };
+
+    const pde = &@as(*L2Table, @ptrFromInt(RecInfo.pdTableAddr(pidx.l4_idx, pidx.l3_idx)))[pidx.l2_idx];
+
+    if (!pde.present) return res;
+
+    if (pde.hudge) {
+        return .{ .entry_ptr = @ptrCast(pde), .lvl = .l2, .ps = .ps2m };
+    }
+
+    const pte = &@as(*L1Table, @ptrFromInt(RecInfo.ptTableAddr(pidx.l4_idx, pidx.l3_idx, pidx.l2_idx)))[pidx.l1_idx];
+    if (!pte.present) return res;
+
+    return .{ .entry_ptr = @ptrCast(pte), .lvl = .l1, .ps = .ps4k };
+}
+
+/// Get virtual address from paging indexes using Higher Half Direct Mapping offset
+pub inline fn hhdmVirtFromPhys(paddr: usize) usize {
+    return paddr + hhdm_offset;
+}
+
+fn Pml4TableFromCr3() struct { []L4Entry, Cr3Structure(false) } {
+    const cr3_formatted: Cr3Structure(false) = @bitCast(cpu.cr3());
+    return .{ cr3_formatted.retrieve_table(L4Table), cr3_formatted };
+}
+
+pub fn logLowestEntryFromVirt(virt: usize) void {
+    const page_entry_info = recLowestEntryFromVirtInfo(virt) catch @panic("Failed to get page entry info for NVMe BAR");
+    log.debug("page entry info: {} ", .{page_entry_info});
+
+    if (page_entry_info.entry_ptr == null) {
+        log.err("Entry not found for virt: 0x{x}", .{virt});
+        return;
+    }
+    switch (page_entry_info.ps) {
+        .ps1g => {
+            const entry: *L3Entry1G = @ptrCast(page_entry_info.entry_ptr);
+            log.debug(".ps1g entry: {any}", .{entry});
+        },
+        .ps2m => {
+            const entry: *L2Entry2M = @ptrCast(page_entry_info.entry_ptr);
+            log.debug(".ps2m entry: {any}", .{entry});
+        },
+        .ps4k => {
+            const entry: *L1Entry = @ptrCast(page_entry_info.entry_ptr);
+            log.debug(".ps4k entry: {any}", .{entry});
+        },
+    }
+}
+
+// pub fn print_tlb() void {
+//     for (pml4t, 0..) |e, i| {
+//         if (e.present) {
+//             log.err("tlb_pml4[{d:0>3}]@{*}: 0x{x} -> {any} of {}", .{ i, &e, e.aligned_address_4kbytes, e.retrieveTable(), e });
+//             for (e.retrieveTable().?) |pdpte| {
+//                 if (pdpte.present) {
+//                     log.err("pdpte: {}", .{pdpte});
+//                     for (pdpte.retrieveTable().?) |pde| {
+//                         if (pde.present) {
+//                             log.err("pde: {}", .{pde});
+//                             //                 for (pde.retrieve_table()) |pte| {
+//                             //                     if (pte.present) {
+//                             //                         log.warn("pte: 0x{x} -> {*}", .{ pte.aligned_address_4kbytes, pte.retrieve_frame_address() });
+//                             //                     }
+//                             //                 }
+//                         }
+//                     }
+//                 }
+//             }
+//         }
+//     }
+// }
+//
+
+// Partially implemented for 4kbytes pages and 2mbytes pages; Does not iterate over page/frame entries
+// // TODO:implement it for 1gbytes and for all offsets inside a page
+// pub fn findPhys(phys: usize) void {
+//     for (pml4t, 0..) |e, lvl4_idx| {
+//         if (e.present) {
+
+//             //log.err("findPhys: tlb_pml4[{d:0>3}]@{*}: 0x{x} -> {any} of {}", .{ i, &e, e.aligned_address_4kbytes, e.retrieveTable(), e });
+//             for (e.retrieveTable().?, 0..) |pdpte, lvl3_idx| {
+//                 if (pdpte.present) {
+//                     //log.err("findPhys: pdpte: {}", .{pdpte});
+//                     for (pdpte.retrieveTable().?, 0..) |pde, lvl2_idx| {
+//                         if (pde.present) {
+//                             //log.err("findPhys: pde: {}", .{pde});
+//                             if (pde.hudge) {
+//                                 const pde_phys = (@as(PagingStructureEntry(.ps2m, .pd), @bitCast(pde)).retrieveFrameVirt().?) << @bitSizeOf(u21);
+//                                 //log.err("findPhys: found pde huge: {}, phys: 0x{x}", .{ pde, phys });
+//                                 if (pde_phys == phys) {
+//                                     log.err("findPhys: found pde huge: pml4t[{d}]={} pdpt[{d}]={}, pd[{d}]={}, phys=0x{x}", .{ lvl4_idx, e, lvl3_idx, pdpte, lvl2_idx, pde, phys });
+//                                     const virt = virtFromIndex(.{ .pml4_idx = @intCast(lvl4_idx), .pdpt_idx = @intCast(lvl3_idx), .pd_idx_or_high_offset = @intCast(lvl2_idx), .pt_idx_or_high_offset = 0, .offset = 0 });
+//                                     log.err("findPhys: virt: 0x{x}", .{virt});
+
+//                                     return;
+//                                 }
+//                             } else {
+//                                 for (pde.retrieveTable().?) |pte| {
+//                                     if (pte.present) {
+//                                         const pte_phys = (@as(PagingStructureEntry(.ps4k, .pt), pte).retrieveFrameVirt().?) << @bitSizeOf(u12);
+//                                         if (pte_phys == phys) {
+//                                             log.err("findPhys: found pte: {}, phys: 0x{x}", .{ pde, phys });
+//                                             return;
+//                                         }
+//                                     }
+//                                 }
+//                             }
+//                         }
+//                     }
+//                 }
+//             }
+//         }
+//     }
+// }
+
+pub fn logVirtInfo(virt: usize) void {
+    log.err("logVirtInfo: Virtual Adddress to check: 0x{x}", .{virt});
+
+    const vaddr_info = recLowestEntryFromVirtInfo(virt) catch |err| {
+        log.err("logVirtInfo: Call function recLowestEntryFromVirtInfo: 0x{x} -> error: {}", .{ virt, err });
+        return;
+    };
+
+    log.debug("Paging Table:  0x{x} -> {any}", .{ virt, vaddr_info });
+    const phys_by_rec = recPhysFromVirt(virt) catch |err| {
+        log.err("logVirtInfo: Call function recPhysFromVirt: 0x{x} -> error: {}", .{ virt, err });
+        return;
+    };
+    log.debug("logVirtInfo: Call function recPhyFromVirt: virt: 0x{x} -> 0x{x}\n", .{ virt, phys_by_rec });
+}
+
+// Variables
+var pml4t: []L4Entry = undefined;
+var pat: PAT = undefined;
+
+pub fn init() !void {
+    log.debug("Initializing...", .{});
+    defer log.debug("Initialized", .{});
+
+    if (hhdm_request.response) |hhdm_response| {
+        hhdm_offset = hhdm_response.offset;
+        log.debug("HHDM offset: 0x{x}", .{hhdm_offset});
+        if (hhdm_offset != 0xFFFF_8000_0000_0000) @panic("Invalid HHDM offset");
+    } else @panic("No HHDM bootloader response available");
+
+    if (paging_mode_request.response) |paging_mode_response| {
+        switch (paging_mode_response.mode) {
+            .four_level => {
+                log.info("4-level paging enabled", .{});
+            },
+            .five_level => {
+                log.info("5-level paging enabled", .{});
+                @panic("5-level paging not supported yet");
+            },
+        }
+    } else @panic("No paging mode bootloader response available");
+
+    // setup PAT
+    pat = PAT{};
+    pat.write(); //set default values
+    pat.read(); //read values to be sure we set it right
+    log.debug("The 0x277 MSR register value after the change: 0x{}", .{pat});
+
+    pml4t, const cr3_formatted = Pml4TableFromCr3();
+    log.debug("PML4 table: {*}, cr3_formated: {}", .{ pml4t.ptr, cr3_formatted });
+
+    // Get ready for recursive paging
+    pml4t[510] = .{ .present = true, .writable = true, .aligned_address_4kbytes = @truncate(cr3_formatted.aligned_address_4kbytes) };
+
+    //const lvl4e = retrieveEntryFromVaddr(Pml4e, .four_level, default_page_size, .lvl4, 0xffff_8000_fe80_0000);
+    log.warn("cr3 -> 0x{x}", .{cpu.cr3()});
+    //log.warn("pml4 ptr -> {*}\n\n", .{pml4t.ptr});
+    //
+    //const vaddr_test = 0xffff_8000_fe80_0000;
+    // const vaddr_test = 0xffff800040132000;
+    // const pidx = indexFromVaddr(vaddr_test);
+    // log.warn("pidx: 0x{x} -> {}", .{ vaddr_test, pidx });
+    // const vaddr_test_info = try recLowestEntryFromVirtInfo(vaddr_test);
+    // log.warn("pde:  0x{x} -> {any}", .{ vaddr_test, vaddr_test_info });
+    // if (vaddr_test_info.entry_ptr == null) {
+    //     log.err("Entry not found for vaddr: 0x{x}", .{vaddr_test});
+    // }
+    // const spec_entry: *Pde2MByte = @ptrCast(vaddr_test_info.entry_ptr);
+    // log.warn("entry of {any}, val={!}\n\n", .{ @TypeOf(spec_entry), spec_entry });
+    // const pte = entryFromVaddr(.pt, vaddr_test);
+    // log.warn("pte: -> {any}, pfn= {*}\n\n", .{ pte.*, pte.retrieveFrame().?.ptr });
+    //
+    //
+    // const phys_pci = try physFromVirtInfo(0xffff_8000_fe80_0000);
+    // log.warn("phys_pci: 0x{any}", .{phys_pci});
+    // log.warn("phys_pci_virt: 0x{x}", .{phys_pci.phys});
+    //
+    // const phys_buddy = try physFromVirtInfo(0xffff80001010a000);
+    // log.warn("phys_buddy: 0x{any}", .{phys_buddy});
+    // log.warn("phys_buddy_virt: 0x{x}", .{phys_buddy.phys});
+
+    // wite loop to iterate over each element of address in the table
+    // we use the fact that limine uses identity mapping and at the same time for the same phys addres HHDM
+    const vt = [_]usize{
+        hhdmVirtFromPhys(0x4d00), //HHDM
+        hhdmVirtFromPhys(0x10_0000),
+        hhdmVirtFromPhys(0x7fa61000),
+        hhdmVirtFromPhys(0x7fa63000),
+        hhdmVirtFromPhys(0xfee0_0000),
+    };
+    for (vt) |vaddr| {
+        logVirtInfo(vaddr);
+
+        physInfoFromVirt(vaddr) catch |err| {
+            log.err("Call function physInfoFromVirt: 0x{x} -> error: {}", .{ vaddr, err });
+            continue;
+        };
+
+        // log.err("Virtual Adddress to check: 0x{x}", .{vaddr});
+
+        // const vaddr_info = try recLowestEntryFromVirtInfo(vaddr);
+        // log.err("Paging Table:  0x{x} -> {any}", .{ vaddr, vaddr_info });
+        // const phys_by_rec = recPhysFromVirt(vaddr) catch |err| {
+        //     log.err("Call function recPhysFromVirtvirt: 0x{x} -> error: {}", .{ vaddr, err });
+        //     continue;
+        // };
+        // log.err("Call function recPhyFromVirt: vaddr: 0x{x} -> 0x{x}\n", .{ vaddr, phys_by_rec });
+
+        // const vaddr_info = try lowestEntryFromVirtInfo(vaddr);
+        // log.err("Paging Table:  0x{x} -> {any}", .{ vaddr, vaddr_info });
+        // const phys_rec = physFromVirt(vaddr) catch |err| {
+        //     log.err("Call function physFromVirtvirt: 0x{x} -> error: {}", .{ vaddr, err });
+        //     continue;
+        // };
+        //log.err("Call function phyFromVirt: vaddr: 0x{x} -> 0x{x}", .{ vaddr, phys_rec });
+    }
+
+    //   log.info("Find phys 0xfee0_0000", .{});
+    //   findPhys(0xfee0_0000);
+
+    //
+    //
+    //
+    // // const pidx511: Index = .{ .pml4_idx = 511, .pdpt_idx = 511, .pd_idx = 0, .pt_idx = 0, .offset = 0 };
+    // // //const vaddr511 = 0xffff_ffff_ffff_f000;
+    // // const vaddr511 = vaddrFromIndex(pidx511);
+    // // //const pidx511 = pagingIndexFromVaddr(vaddr511);
+    // // log.warn("pidx511 -> {}", .{pidx511});
+    // // const pml4e511 = entryFromVaddr(.pml4, vaddr511);
+    // // log.warn("pml4e511: -> {}, vaddr=0x{x}, ptr={*}, ptr.table={*}, aligned_addres=0x{x}", .{ pml4e511.*, vaddr511, pml4e511, pml4e511.retrieveTable().?, pml4e511.aligned_address_4kbytes });
+    // //
+    // // const pidx510: Index = .{ .pml4_idx = 510, .pdpt_idx = 510, .pd_idx = 510, .pt_idx = 510, .offset = 0 };
+    // // const vaddr510 = vaddrFromIndex(pidx510);
+    // // log.warn("pidx510 -> {}", .{pidx510});
+    // // const pml4e510 = entryFromVaddr(.pml4, vaddr510);
+    // // log.warn("pml4e510: -> {}, ptr={*}", .{ pml4e510.*, pml4e510 });
+    // //
+    // // log.warn("cr4: 0b{b:0>64}", .{@as(u64, cpu.cr4())});
+    // // log.warn("cr3: 0b{b:0>64}", .{@as(u64, cpu.cr3())});
+    // //
+    // // log.warn("pt:     0xFFFFFF00_00000000->0xFFFFFF7F_FFFFFFFF: {}->{}, diff: 0x{x}", .{ indexFromVaddr(0xFFFFFF00_00000000), indexFromVaddr(0xFFFFFF7F_FFFFFFFF), (0xFFFFFF7F_FFFFFFFF - 0xFFFFFF00_00000000) });
+    // // const x = indexFromVaddr(0xFFFFFF7F_8000000);
+    // // _ = &x;
+    // // log.warn("\n\npt:    0xFFFF_FF7F8_000_0000->0xFFFFFF7F_BFFFFFFF : {}->{}, diff: 0x{x}", .{ indexFromVaddr(0xffff_ff7f_8000_0000), indexFromVaddr(0xFFFFFF7F_BFFFFFFF), (0xFFFFFF7F_BFFFFFFF - 0xFFFFFF7F_8000000) });
+    // // log.warn("pdpt: 0xFFFFFF7F_BFC00000->0xFFFFFF7F_BFDFFFFF  : {}->{}, diff: 0x{x}", .{ indexFromVaddr(0xFFFFFF7F_BFC00000), indexFromVaddr(0xFFFFFF7F_BFDFFFFF), (0xFFFFFF7F_BFDFFFFF - 0xFFFFFF7F_BFC00000) });
+    // // log.warn("pml4: 0xFFFFFF7F_BFDFE000 ->0xFFFFFF7F_BFDFEFFF   : {}->{}, diff:0x{x}", .{ indexFromVaddr(0xFFFFFF7F_BFDFE000), indexFromVaddr(0xFFFFFF7F_BFDFEFFF), (0xFFFFFF7F_BFDFEFFF - 0xFFFFFF7F_BFDFE000) });
+    // // log.warn("pml4: 0xFFFFFF7F_BFDFE000 ->0xFFFFFF7F_BFDFEFFF   : {}->{}, diff:0x{x}", .{ indexFromVaddr(0xFFFFFF7F_BFDFE000), indexFromVaddr(0xFFFFFF7F_BFDFEFFF), (0xFFFFFF7F_BFDFEFFF - 0xFFFFFF7F_BFDFE000) });
+    // //
+    // // log.warn("\n\nkernel: {}->{}", .{ indexFromVaddr(0xffffff7f80000000), indexFromVaddr(0xffffff7f8009cb88) });
+    // //
+    // // const vmm_pml4_2 = tableFromVaddr(.pml4, 0xFFFFFF7F_BFDFFFFF) orelse @panic("Table not found");
+    // // log.warn("vmm_pml4_2: 0xFFFFFF7F_BFDFE008 : {*}, len={d}, [0]={}@{*}, [511]={}@{*}", .{ vmm_pml4_2.ptr, vmm_pml4_2.len, vmm_pml4_2[0], &vmm_pml4_2[0], vmm_pml4_2[511], &vmm_pml4_2[511] });
+    // //
+    // // const vmm_pml4 = tableFromVaddr(.pml4, 0xFFFFFF7F_BFC00000) orelse @panic("Table not found [2a]");
+    // // log.warn("vmm_pml4: 0xFFFFFF7F_BFC00000 : {*}, len={d}, [0]={}@{*}, [511]={}@{*}", .{ vmm_pml4.ptr, vmm_pml4.len, vmm_pml4[0], &vmm_pml4[0], vmm_pml4[511], &vmm_pml4[511] });
+    // //
+    // // const vmm_pdpt = tableFromVaddr(.pdpt, 0xFFFFFF7F_BFC00000) orelse @panic("Table not found [2b]");
+    // // log.warn("vmm_pdpt: 0xFFFFFF7F_BFC00000 : {*}, len={d}, [0]={}@{*}, [511]={}@{*}", .{ vmm_pdpt.ptr, vmm_pdpt.len, vmm_pdpt[0], &vmm_pdpt[0], vmm_pdpt[511], &vmm_pdpt[511] });
+    // //
+    // // // recursive in 510, not 511 cause limine occupies it
+    // // log.warn("cr3_formatted: {0}, {0b:0>40}, 0x{0x}", .{cr3_formatted.aligned_address_4kbytes});
+    // // pml4t[510] = .{ .present = true, .writable = true, .aligned_address_4kbytes = @truncate(cr3_formatted.aligned_address_4kbytes) }; //we ignore the last bit
+    // // cpu.invlpg(@intFromPtr(&pml4t[510]));
+    // // log.err("&pml4[510]={*}", .{&pml4t[510]});
+    // //
+    // // //Dla PDPT
+    // // // const pdpt_pidx = .{ .pml4_idx = 510, .pdpt_idx = 510, .pd_idx = 0, .pt_idx = 0, .offset = 0 };
+    // // //  const pdpt510 = entryFromVaddr(.pdpt, vaddrFromIndex(pdpt_pidx));
+    // // //  pdpt510.* = .{ .present = true, .writable = true, .aligned_address_4kbytes = @truncate(cr3_formatted.aligned_address_4kbytes) };
+    // //
+    // // //Dla PD
+    // // // const pd_pidx = .{ .pml4_idx = 510, .pdpt_idx = 510, .pd_idx = 510, .pt_idx = 0, .offset = 0 };
+    // // // const pd510 = entryFromVaddr(.pd, vaddrFromIndex(pd_pidx));
+    // // // pd510.* = .{ .present = true, .writable = true, .aligned_address_4kbytes = @truncate(pdpt510.aligned_address_4kbytes) };
+    // //
+    // // // Dla PT
+    // // // const pt_pidx = .{ .pml4_idx = 510, .pdpt_idx = 0, .pd_idx = 0, .pt_idx = 0, .offset = 0 };
+    // // // const pt510 = entryFromVaddr(.pt, vaddrFromIndex(pt_pidx));
+    // // // pt510.* = .{ .present = true, .writable = true, .aligned_address_4kbytes = @truncate(pd510.aligned_address_4kbytes) };
+    // //
+    // // // const pidx510: Index = .{ .pml4_idx = 510, .pdpt_idx = 0, .pd_idx = 0, .pt_idx = 0 , .offset = 0 };
+    // // // const vaddr510 = vaddrFromIndex(pidx510);
+    // // // log.warn("pidx510 -> {}", .{pidx510});
+    // // // const pml4e510 = entryFromVaddr(.pml4, vaddr510);
+    // // // log.warn("pml4e510: -> {}, ptr={*}", .{ pml4e510.*, pml4e510 });
+    // //
+    //print_tlb();
+    // //
+    // // // const tphys = physFromVirt(0xFFFFFF7F_8000000);
+    // // // log.warn("tphys: 0x{x}", .{tphys});
+
+}
+
+// CR3 structure
+pub fn Cr3Structure(comptime pcid: bool) type {
+    if (pcid) {
+        return packed struct(RawEntry) {
+            const Self = @This();
+            pcid: u12, //0-11
+            aligned_address_4kbytes: u40, //12-51- PMPL4|PML5 address
+            rsrvd: u12 = 0, //52-63
+
+            pub fn retrieve_table(self: Self, T: type) *T {
+                return @ptrFromInt(hhdmVirtFromPhys(self.aligned_address_4kbytes << @bitSizeOf(u12)));
+            }
+        };
+    } else {
+        return packed struct(RawEntry) {
+            const Self = @This();
+            ignrd_a: u3, //0-2
+            write_though: bool, //3
+            cache_disabled: bool, //4
+            ignrd_b: u7, //5-11
+            aligned_address_4kbytes: u40, //12-51- PMPL4|PML5 address
+            rsrvd: u12 = 0, //52-63
+
+            pub fn retrieve_table(self: Self, T: type) *T {
+                return @ptrFromInt(hhdmVirtFromPhys(self.aligned_address_4kbytes << @bitSizeOf(u12)));
+            }
+        };
+    }
+}
+
+// PAT (Page Attribute Table) specific code
 pub const PATType = enum(u8) {
     uncacheable = 0x00, //UC
     write_combining = 0x01, //WC
@@ -142,777 +966,4 @@ pub fn adjustPageAreaPAT(virt: usize, sz: usize, req_pat: PATType) !void {
 
 fn flushTLB(virt: usize) void {
     cpu.invlpg(virt);
-}
-
-fn RecursiveInfo(comptime recursive_index: u9) type {
-    return struct {
-        const rec_idx: usize = recursive_index; //510
-        const sign = 0o177777 << 48; //sign extension (always 1 for second half of the memory space)
-
-        // retrieve the page table indices of the address that we want to translate
-        pub inline fn pml4TableAddr() usize {
-            return sign | (rec_idx << 39) | (rec_idx << 30) | (rec_idx << 21) | (rec_idx << 12);
-        }
-        pub inline fn pdptTablAddr(pml4_idx: usize) usize {
-            return sign | (rec_idx << 39) | (rec_idx << 30) | (rec_idx << 21) | (pml4_idx << 12);
-        }
-        pub inline fn pdTableAddr(pml4_idx: usize, pdpt_idx: usize) usize {
-            return sign | (rec_idx << 39) | (rec_idx << 30) | (pml4_idx << 21) | (pdpt_idx << 12);
-        }
-        pub inline fn ptTableAddr(pml4_idx: usize, pdpt_idx: usize, pd_idx: usize) usize {
-            return sign | (rec_idx << 39) | (pml4_idx << 30) | (pdpt_idx << 21) | (pd_idx << 12);
-        }
-    };
-}
-
-const PageSize = enum(u32) { ps4k = 0x1000, ps2m = 0x200000, ps1g = 0x40000000 };
-pub const default_page_size: PageSize = @enumFromInt(config.mem_page_size);
-
-const PagingMode = enum(u1) {
-    four_level = 0,
-    five_level = 1,
-};
-
-pub fn Cr3Structure(comptime pcid: bool) type {
-    if (pcid) {
-        return packed struct(GenericEntry) {
-            const Self = @This();
-            pcid: u12, //0-11
-            aligned_address_4kbytes: u40, //12-51- PMPL4|PML5 address
-            rsrvd: u12 = 0, //52-63
-
-            pub fn retrieve_table(self: Self, T: type) *T {
-                return @ptrFromInt(hhdmVirtFromPhys(self.aligned_address_4kbytes << @bitSizeOf(u12)));
-            }
-        };
-    } else {
-        return packed struct(GenericEntry) {
-            const Self = @This();
-            ignrd_a: u3, //0-2
-            write_though: bool, //3
-            cache_disabled: bool, //4
-            ignrd_b: u7, //5-11
-            aligned_address_4kbytes: u40, //12-51- PMPL4|PML5 address
-            rsrvd: u12 = 0, //52-63
-
-            pub fn retrieve_table(self: Self, T: type) *T {
-                return @ptrFromInt(hhdmVirtFromPhys(self.aligned_address_4kbytes << @bitSizeOf(u12)));
-            }
-        };
-    }
-}
-
-// the lowest level entry stoing the frame address
-fn PageLeafEntry(comptime ps: PageSize) type {
-    return switch (ps) {
-        .ps4k => Pte,
-        .ps2m => Pde2MByte,
-        .ps1g => Pdpte1Gbyte,
-    };
-}
-
-pub const entries_count: usize = 512;
-const default_recursive_index: u9 = 510; //0x1FE
-const RecInfo = RecursiveInfo(default_recursive_index); //0x776
-
-const GenericEntry = usize;
-pub const GenericEntryInfo = struct {
-    entry_ptr: ?*GenericEntry,
-    lvl: Level,
-    ps: PageSize,
-};
-
-// TODO: usngnamespace does not work in case of the fields
-pub fn PagingStructureEntry(comptime ps: PageSize, comptime lvl: Level) type {
-    //return packed struct(GenericEntry) {
-    return switch (lvl) {
-        .pml4 => packed struct(GenericEntry) {
-            const Self = @This();
-            present: bool = false, //0
-            writable: bool = false, //1
-            user: bool = false, //2
-            write_through: bool = false, //3
-            cache_disabled: bool = false, //4
-            accessed: bool = false, //5
-            dirty: bool = false, //6
-            rsrvd_a: u1 = 0, //7
-            ignrd_a: u3 = 0, //8-10
-            restart: u1 = 0, //11
-            aligned_address_4kbytes: u39, //12-50- PML3 address
-            rsrvd_b: u1 = 0, //51
-            ignrd_b: u11 = 0, //52-62
-            execute_disable: bool = false, //63
-
-            pub fn retrieveTable(self: Self) ?[]Pdpte {
-                return if (self.present) @as(*Pdpt, @ptrFromInt(hhdmVirtFromPhys(self.aligned_address_4kbytes << @bitSizeOf(u12)))) else null;
-            }
-        },
-        // .pdpte1gbytes
-        .pdpt => switch (ps) {
-            .ps1g => packed struct(GenericEntry) {
-                const Self = @This();
-                present: bool, //0
-                writable: bool, //1
-                user: bool, //2
-                write_through: bool, //3
-                cache_disabled: bool, //4
-                accessed: bool, //5
-                dirty: bool, //6
-                huge: bool, //7
-                global: bool, //8
-                ignrd_a: u2, //9-10
-                restart: u1, //11
-                pat: u1, //12
-                rsrvd_a: u17, //13-29
-                aligned_address_1gbytes: u21, //30-50
-                rsrvd_b: u1, //51 //must be 0
-                ignrd_b: u7, //52-58
-                protection_key: u4, //59-62
-                execute_disable: bool, //63
-
-                pub inline fn retrieveFrameVirt(self: Self) ?usize {
-                    return if (self.present) self.aligned_address_1gbytes else null;
-                }
-
-                pub inline fn retrieveFrame(self: Self) ?[]usize {
-                    return if (self.present) @as(*[.ps1g]GenericEntry, @ptrFromInt(self.retrieveFrameVirt().?)) else null;
-                }
-            },
-            .ps4k, .ps2m => packed struct(GenericEntry) {
-                const Self = @This();
-                present: bool = false, //0
-                writable: bool = false, //1
-                user: bool = false, //2
-                write_through: bool = false, //3
-                cache_disabled: bool = false, //4
-                accessed: bool = false, //5
-                ignrd_a: u1 = 0, //6
-                hudge: bool = false, //7
-                ignrd_b: u3 = 0, //8-10
-                restart: u1 = 0, //11
-                aligned_address_4kbytes: u39, //12-50
-                rsrvd_a: u1 = 0, //50
-                ignr_b: u11 = 0, //52-62
-                execute_disable: bool = false, //63
-
-                pub inline fn retrieveTable(self: Self) ?[]Pde {
-                    return if (self.present) @as(*Pd, @ptrFromInt(hhdmVirtFromPhys(self.aligned_address_4kbytes << @bitSizeOf(u12)))) else null;
-                }
-            },
-            //            else => @compileError("Unsupported page size:" ++ @tagName(ps)),
-        },
-        .pd => switch (ps) {
-            .ps2m => packed struct(GenericEntry) {
-                const Self = @This();
-                present: bool = false, //0
-                writable: bool = false, //1
-                user: bool = false, //2
-                write_through: bool = false, //3
-                cache_disabled: bool = false, //4
-                accessed: bool = false, //5
-                dirty: bool = false, //6
-                hudge: bool = false, //7
-                global: bool = false, //8
-                ignrd_a: u2 = 0, //9-10
-                restart: u1 = 0, //11
-                pat: u1 = 0, //12
-                rsrvd_a: u8 = 0, //13-20
-                aligned_address_2mbytes: u30, //21-50
-                rsrvd_b: u1 = 0, //51
-                ignrd_b: u7 = 0, //52-58
-                protection_key: u4 = 0, //59-62
-                execute_disable: bool = false, //63
-
-                pub inline fn retrieveFrameVirt(self: Self) ?usize {
-                    return if (self.present) self.aligned_address_2mbytes else null;
-                }
-
-                pub inline fn retrievFrame(self: Self) ?[]usize {
-                    return if (self.present) @as(*[.ps2m]usize, @ptrFromInt(self.retrieveFrameVirt().?)) else null;
-                }
-            },
-            .ps4k => packed struct(GenericEntry) {
-                const Self = @This();
-                present: bool = false, //0
-                writable: bool = false, //1
-                user: bool = false, //2
-                write_through: bool = false, //3
-                cache_disabled: bool = false, //4
-                accessed: bool = false, //5
-                ignrd_a: bool = false, //6
-                hudge: bool = false, //7 //must be 0
-                ignrd_b: u3 = 0, //8-10
-                restart: u1 = 0, //11
-                aligned_address_4kbytes: u39, //12-50
-                rsrvd_a: u1 = 0, //51-51 //must be 0
-                ignrd_c: u11 = 0, //52-62
-                execute_disable: bool = true, //63
-                pub inline fn retrieveTable(self: Self) ?[]Pte {
-                    return if (self.present) @as(*Pt, @ptrFromInt(hhdmVirtFromPhys(self.aligned_address_4kbytes << @bitSizeOf(u12)))) else null;
-                }
-            },
-            else => @compileError("Unsupported page size:" ++ ps),
-        },
-        .pt => packed struct(GenericEntry) {
-            const Self = @This();
-            present: bool = false, //0
-            writable: bool = false, //1
-            user: bool = false, //2
-            write_through: bool = false, //3
-            cache_disabled: bool = false, //4
-            accessed: bool = false, //5
-            dirty: bool = false, //6
-            pat: u1 = 0, //7
-            global: bool = false, //8
-            ignrd_a: u2 = 0, //9-10
-            restart: u1 = 0, //11
-            aligned_address_4kbytes: u39, //12-50
-            rsrvd_a: u1 = 0, //51-51 //must be 0
-            ignrd_b: u7 = 0, //52-58
-            protection_key: u4 = 0, //5 w9-62
-            execute_disable: bool = false, //63
-
-            pub inline fn retrieveFrameVirt(self: Self) ?usize {
-                return if (self.present) self.aligned_address_4kbytes else null;
-            }
-
-            pub inline fn retrieveFrame(self: Self) ?[]usize {
-                return if (self.present) @as(*[@intFromEnum(PageSize.ps4k)]GenericEntry, @ptrFromInt(self.retrieveFrameVirt().?)) else null;
-            }
-        },
-    };
-}
-
-pub const Pml4e = PagingStructureEntry(default_page_size, .pml4);
-pub const Pdpte = PagingStructureEntry(default_page_size, .pdpt);
-pub const Pdpte1Gbyte = PagingStructureEntry(.ps1g, .pdpt);
-pub const Pde = PagingStructureEntry(default_page_size, .pd);
-pub const Pde2MByte = PagingStructureEntry(.ps2m, .pd);
-pub const Pte = PagingStructureEntry(default_page_size, .pt);
-pub const Pml4 = [entries_count]Pml4e;
-pub const Pdpt = [entries_count]Pdpte;
-pub const Pd = [entries_count]Pde;
-pub const Pt = [entries_count]Pte;
-
-/// Holds indexes of all paging tables
-/// each table holds indexes of 512 entries, so we need only 9 bytes to store index
-/// Offset is 12 bits to address 4KiB page
-const Index = struct {
-    const Self = @This();
-    pml4_idx: u9, //pml4
-    pdpt_idx: u9, //pdpt
-    pd_idx_or_high_offset: u9, //pd
-    pt_idx_or_high_offset: u9, //pt
-    //offset: u12,
-    offset: u12, //12 bites for 4k pages, 21 for 2m pages, 30 for 1g pages
-
-    pub fn yieldOffset(self: Self, comptime page_size: PageSize) switch (page_size) {
-        .ps4k => u12,
-        .ps2m => u21,
-        .ps1g => u30,
-    } {
-        return switch (page_size) {
-            .ps4k => self.offset,
-            .ps2m => (@as(u21, self.pt_idx_or_high_offset) << 12) + self.offset,
-            .ps1g => (@as(u30, self.pd_idx_or_high_offset) << 21) + (@as(u21, self.pt_idx_or_high_offset) << 12) + self.offset,
-        };
-    }
-};
-
-const Level = enum(u3) {
-    pml4 = 4,
-    pdpt = 3,
-    pd = 2,
-    pt = 1,
-};
-
-pub export var hhdm_request: limine.HhdmRequest = .{};
-pub export var paging_mode_request: limine.PagingModeRequest = .{ .mode = .four_level, .flags = 0 }; //default L4 paging
-var hhdm_offset: usize = undefined;
-
-/// Get paging indexes from virtual address
-/// It maps 48-bit virtual address to 9-bit indexes of all 52 physical address bits
-/// src osdev: "Virtual addresses in 64-bit mode must be canonical, that is,
-/// the upper bits of the address must either be all 0s or all 1s.
-// For systems supporting 48-bit virtual address spaces, the upper 16 bits must be the same"
-pub inline fn buildIndex(virt: usize) Index {
-    return .{
-        .pml4_idx = @truncate(virt >> 39), //47->39
-        .pdpt_idx = @truncate(virt >> 30), //39->30
-        .pd_idx_or_high_offset = @truncate(virt >> 21), //30->21
-        .pt_idx_or_high_offset = @truncate(virt >> 12), //21->12
-        .offset = @truncate(virt), //12 bites
-    };
-}
-
-// test indexFromVaddr {
-//     try std.testing.expect(Index{ .lvl4 = 0, .lvl3 = 0, .lvl2 = 0, .pt = 2, .offset = 1 }, indexFromVaddr(0x2001));
-// }
-
-// Get virtual address from paging indexes
-pub inline fn virtFromIndex(pidx: Index) usize {
-    const addr = (@as(usize, pidx.pml4_idx) << 39) | (@as(usize, pidx.pdpt_idx) << 30) | (@as(usize, pidx.pd_idx_or_high_offset) << 21) | @as(usize, pidx.pt_idx_or_high_offset) << 12 | pidx.offset;
-    switch (addr & @as(usize, 1) << 47) {
-        0 => return addr & 0x7FFF_FFFF_FFFF,
-        @as(usize, 1) << 47 => return addr | 0xFFFF_8000_0000_0000,
-        else => @panic("Invalid address"),
-    }
-}
-
-// Recursive get physical address from virtual address
-pub fn recPhysFromVirtInfo(virt: usize) !struct { phys: usize, lvl: Level, ps: PageSize } {
-    const pidx = buildIndex(virt);
-
-    // check if pml4 entry is present
-    const pml4e = @as(*Pml4, @ptrFromInt(RecInfo.pml4TableAddr()))[pidx.pml4_idx];
-    if (!pml4e.present) return error.PageFault;
-
-    // check if pdpt entry is present
-    const pdpte = @as(*Pdpt, @ptrFromInt(RecInfo.pdptTablAddr(pidx.pml4_idx)))[pidx.pdpt_idx];
-    if (!pdpte.present) return error.PageFault;
-
-    if (pdpte.hudge) {
-        return .{ .phys = (@as(PagingStructureEntry(.ps1g, .pdpt), @bitCast(pdpte)).retrieveFrameVirt().? << @bitSizeOf(u30)) + pidx.yieldOffset(.ps1g), .lvl = .pdpt, .ps = .ps1g };
-    }
-
-    // check if pd entry is present
-    const pde = @as(*Pd, @ptrFromInt(RecInfo.pdTableAddr(pidx.pml4_idx, pidx.pdpt_idx)))[pidx.pd_idx_or_high_offset];
-    if (!pde.present) return error.PageFault;
-
-    if (pde.hudge) {
-        return .{ .phys = (@as(PagingStructureEntry(.ps2m, .pd), @bitCast(pde)).retrieveFrameVirt().? << @bitSizeOf(u21)) + pidx.yieldOffset(.ps2m), .lvl = .pd, .ps = .ps2m };
-    }
-
-    // check if pt entry is present
-    const pte = @as(*Pt, @ptrFromInt(RecInfo.ptTableAddr(pidx.pml4_idx, pidx.pdpt_idx, pidx.pd_idx_or_high_offset)))[pidx.pt_idx_or_high_offset];
-    if (!pte.present) return error.PageFault;
-
-    return .{ .phys = (@as(PagingStructureEntry(.ps4k, .pt), pte).retrieveFrameVirt().? << @bitSizeOf(u12)) + pidx.yieldOffset(.ps4k), .lvl = .pt, .ps = .ps4k };
-}
-
-pub inline fn recPhysFromVirt(virt: usize) !usize {
-    const info = try recPhysFromVirtInfo(virt);
-    return info.phys;
-}
-
-inline fn recTableFromIndex(comptime lvl: Level, pidx: Index) switch (lvl) {
-    .pml4 => ?[]Pml4e,
-    .pdpt => ?[]Pdpte,
-    .pd => ?[]Pde,
-    .pt => ?[]Pte,
-} {
-    switch (lvl) {
-        .pml4 => {
-            return @as(*Pml4, @ptrFromInt(RecInfo.pml4TableAddr()))[0..entries_count];
-        },
-        .pdpt => {
-            return @as(*Pdpt, @ptrFromInt(RecInfo.pdptTablAddr(pidx.pml4_idx)))[0..entries_count];
-        },
-        .pd => {
-            return @as(*Pd, @ptrFromInt(RecInfo.pdTableAddr(pidx.pml4_idx, pidx.pdpt_idx)))[0..entries_count];
-        },
-        .pt => {
-            return @as(*Pt, @ptrFromInt(RecInfo.ptTableAddr(pidx.pml4_idx, pidx.pdpt_idx, pidx.pd_idx_or_high_offset)))[0..entries_count];
-        },
-    }
-}
-
-fn recTableFromVirt(comptime lvl: Level, virt: usize) switch (lvl) {
-    .pml4 => ?[]Pml4e,
-    .pdpt => ?[]Pdpte,
-    .pd => ?[]Pde,
-    .pt => ?[]Pte,
-} {
-    const pidx = buildIndex(virt);
-    return recTableFromIndex(lvl, pidx);
-}
-
-/// Limine bootloader allocates mixed size pages in reclaimable memory; We need to remap them into
-/// requestaded size pages. tps is the requested page size and lvl is the level of the page table to handle.
-/// We could upgrade the page size e.g. from 4K, 2M to 1G, or downgrade from 1G to 2M or 4K.
-// fn recRemapPageTables(comptime lvl: Level, comptime tps: PageSize, allocator: std.mem.Allocator, virt: usize) !usize {
-//     //_ = lvl;
-//     _ = tps;
-//     //_ = allocator;
-//     //@compileError("Not implemented");
-
-//     const pidx = buildIndex(virt);
-
-//     switch (lvl) {
-//         .pml4 => {
-//             std.debug.assert(pidx.pml4_idx == default_recursive_index and pidx.pdpt_idx == default_recursive_index and pidx.pd_idx_or_high_offset == default_recursive_index and pidx.pt_idx_or_high_offset == default_recursive_index);
-
-//             var new_pml4t: []Pml4e = undefined;
-//             if (pidx.offset == 0) new_pml4t = try dupePageStructTable(Pml4e, allocator, @as([*]Pml4e, @ptrFromInt(virt))[0..entries_count]);
-
-//             for (0..entries_count) |i| {
-//                 const new_pml4e = &@as(*Pml4, @ptrFromInt(RecInfo.pml4TableAddr()))[i];
-//                 if (!new_pml4e.present) continue;
-
-//                 log.debug("remap virt[{d}]: 0x{x} == 0x{x} pml4.pidx: {any}, pml4e: {any}, pml4e: {*}, aligned_adress_4kb=0x{x}", .{ i, virt, virtFromIndex(pidx), pidx, new_pml4e, new_pml4t.ptr, new_pml4e.aligned_address_4kbytes << 12 });
-
-//                 const pdpt_virt = recRemapPageTables(.pdpt, tps, allocator, virt + i) catch return error.PageFault;
-//                 const pdpt_phys = recPhysFromVirt(pdpt_virt);
-//                 new_pml4e.aligned_address_4kbytes = @as(u39, pdpt_phys >> 12);
-//             }
-//             return @intFromPtr(new_pml4t);
-//         },
-//         .pdpt => {
-//             //const pdpte = @as(*Pdpt, @ptrFromInt(RecInfo.pdptTablAddr(0)))[0..entries_count];
-//             //dupePageStructTable(allocator, pdpte) catch return error.PageFault;
-
-//             log.debug("remap virt: 0x{x} pdpt.pidx: {any}", .{ virtFromIndex(pidx), pidx });
-//         },
-//         .pd => {
-//             //const pde = @as(*Pd, @ptrFromInt(RecInfo.pdTableAddr(0, 0)))[0..entries_count];
-//             //dupePageStructTable(allocator, pde) catch return error.PageFault;
-//             log.debug("remap pd.pidx: {any}", .{pidx});
-//         },
-//         .pt => {
-//             //const pte = @as(*Pt, @ptrFromInt(RecInfo.ptTableAddr(0, 0, 0)))[0..entries_count];
-//             //dupePageStructTable(allocator, pte) catch return error.PageFault;
-//             log.debug("remap pt.pidx: {any}", .{pidx});
-//         },
-//     }
-// }
-
-// pub fn remapPageTables(comptime tps: PageSize, allocator: std.mem.Allocator) !void {
-//     // build index from the virtual address of the pml4 table
-//     const pidx = buildIndex(RecInfo.pml4TableAddr());
-//     return recRemapPageTables(.pml4, tps, allocator, virtFromIndex(pidx)) catch return error.PageFault;
-// }
-
-// fn dupePageStructTable(comptime T: type, allocator: std.mem.Allocator, src: []T) ![]T {
-//     // no matter what page size we need to allocate 4kbytes aligned page, but if you use for instance Arena Allocator, then
-//     // we do not controll the alignment, so it is better to aligned imperatively
-//     const dst = allocator.allocWithOptions(T, entries_count, @intFromEnum(PageSize.ps4k), null) catch |err| {
-//         log.err("Failed to allocate page table: {any}", .{err});
-//         return error.PageFault;
-//     };
-//     @memcpy(dst.ptr, src);
-//     return dst;
-// }
-
-pub fn recLowestEntryFromVirtInfo(virt: usize) !GenericEntryInfo {
-    const pidx = buildIndex(virt);
-
-    var res: GenericEntryInfo = .{ .entry_ptr = null, .lvl = .pml4, .ps = .ps4k };
-
-    // check if pml4 entry is present
-    const pml4e = &@as(*Pml4, @ptrFromInt(RecInfo.pml4TableAddr()))[pidx.pml4_idx];
-    if (!pml4e.present) return error.PageFault;
-
-    res = .{ .entry_ptr = @ptrCast(pml4e), .lvl = .pml4, .ps = .ps4k };
-
-    // check if pdpt entry is present
-    const pdpte = &@as(*Pdpt, @ptrFromInt(RecInfo.pdptTablAddr(pidx.pml4_idx)))[pidx.pdpt_idx];
-
-    if (!pdpte.present) return res;
-
-    if (pdpte.hudge) {
-        return .{ .entry_ptr = @ptrCast(pdpte), .lvl = .pdpt, .ps = .ps1g };
-    }
-
-    res = .{ .entry_ptr = @ptrCast(pdpte), .lvl = .pdpt, .ps = .ps2m };
-
-    const pde = &@as(*Pd, @ptrFromInt(RecInfo.pdTableAddr(pidx.pml4_idx, pidx.pdpt_idx)))[pidx.pd_idx_or_high_offset];
-
-    if (!pde.present) return res;
-
-    if (pde.hudge) {
-        return .{ .entry_ptr = @ptrCast(pde), .lvl = .pd, .ps = .ps2m };
-    }
-
-    const pte = &@as(*Pt, @ptrFromInt(RecInfo.ptTableAddr(pidx.pml4_idx, pidx.pdpt_idx, pidx.pd_idx_or_high_offset)))[pidx.pt_idx_or_high_offset];
-    if (!pte.present) return res;
-
-    return .{ .entry_ptr = @ptrCast(pte), .lvl = .pt, .ps = .ps4k };
-}
-
-/// Get virtual address from paging indexes using Higher Half Direct Mapping offset
-pub inline fn hhdmVirtFromPhys(paddr: usize) usize {
-    return paddr + hhdm_offset;
-}
-
-fn Pml4TableFromCr3() struct { []Pml4e, Cr3Structure(false) } {
-    const cr3_formatted: Cr3Structure(false) = @bitCast(cpu.cr3());
-    return .{ cr3_formatted.retrieve_table(Pml4), cr3_formatted };
-}
-
-pub fn logLowestEntryFromVirt(virt: usize) void {
-    const page_entry_info = recLowestEntryFromVirtInfo(virt) catch @panic("Failed to get page entry info for NVMe BAR");
-    log.debug("page entry info: {} ", .{page_entry_info});
-
-    if (page_entry_info.entry_ptr == null) {
-        log.err("Entry not found for virt: 0x{x}", .{virt});
-        return;
-    }
-    switch (page_entry_info.ps) {
-        .ps1g => {
-            const entry: *Pdpte1Gbyte = @ptrCast(page_entry_info.entry_ptr);
-            log.debug(".ps1g entry: {any}", .{entry});
-        },
-        .ps2m => {
-            const entry: *Pde2MByte = @ptrCast(page_entry_info.entry_ptr);
-            log.debug(".ps2m entry: {any}", .{entry});
-        },
-        .ps4k => {
-            const entry: *Pte = @ptrCast(page_entry_info.entry_ptr);
-            log.debug(".ps4k entry: {any}", .{entry});
-        },
-    }
-}
-
-// pub fn print_tlb() void {
-//     for (pml4t, 0..) |e, i| {
-//         if (e.present) {
-//             log.err("tlb_pml4[{d:0>3}]@{*}: 0x{x} -> {any} of {}", .{ i, &e, e.aligned_address_4kbytes, e.retrieveTable(), e });
-//             for (e.retrieveTable().?) |pdpte| {
-//                 if (pdpte.present) {
-//                     log.err("pdpte: {}", .{pdpte});
-//                     for (pdpte.retrieveTable().?) |pde| {
-//                         if (pde.present) {
-//                             log.err("pde: {}", .{pde});
-//                             //                 for (pde.retrieve_table()) |pte| {
-//                             //                     if (pte.present) {
-//                             //                         log.warn("pte: 0x{x} -> {*}", .{ pte.aligned_address_4kbytes, pte.retrieve_frame_address() });
-//                             //                     }
-//                             //                 }
-//                         }
-//                     }
-//                 }
-//             }
-//         }
-//     }
-// }
-//
-
-// Partially implemented for 4kbytes pages and 2mbytes pages; Does not iterate over page/frame entries
-// // TODO:implement it for 1gbytes and for all offsets inside a page
-// pub fn findPhys(phys: usize) void {
-//     for (pml4t, 0..) |e, lvl4_idx| {
-//         if (e.present) {
-
-//             //log.err("findPhys: tlb_pml4[{d:0>3}]@{*}: 0x{x} -> {any} of {}", .{ i, &e, e.aligned_address_4kbytes, e.retrieveTable(), e });
-//             for (e.retrieveTable().?, 0..) |pdpte, lvl3_idx| {
-//                 if (pdpte.present) {
-//                     //log.err("findPhys: pdpte: {}", .{pdpte});
-//                     for (pdpte.retrieveTable().?, 0..) |pde, lvl2_idx| {
-//                         if (pde.present) {
-//                             //log.err("findPhys: pde: {}", .{pde});
-//                             if (pde.hudge) {
-//                                 const pde_phys = (@as(PagingStructureEntry(.ps2m, .pd), @bitCast(pde)).retrieveFrameVirt().?) << @bitSizeOf(u21);
-//                                 //log.err("findPhys: found pde huge: {}, phys: 0x{x}", .{ pde, phys });
-//                                 if (pde_phys == phys) {
-//                                     log.err("findPhys: found pde huge: pml4t[{d}]={} pdpt[{d}]={}, pd[{d}]={}, phys=0x{x}", .{ lvl4_idx, e, lvl3_idx, pdpte, lvl2_idx, pde, phys });
-//                                     const virt = virtFromIndex(.{ .pml4_idx = @intCast(lvl4_idx), .pdpt_idx = @intCast(lvl3_idx), .pd_idx_or_high_offset = @intCast(lvl2_idx), .pt_idx_or_high_offset = 0, .offset = 0 });
-//                                     log.err("findPhys: virt: 0x{x}", .{virt});
-
-//                                     return;
-//                                 }
-//                             } else {
-//                                 for (pde.retrieveTable().?) |pte| {
-//                                     if (pte.present) {
-//                                         const pte_phys = (@as(PagingStructureEntry(.ps4k, .pt), pte).retrieveFrameVirt().?) << @bitSizeOf(u12);
-//                                         if (pte_phys == phys) {
-//                                             log.err("findPhys: found pte: {}, phys: 0x{x}", .{ pde, phys });
-//                                             return;
-//                                         }
-//                                     }
-//                                 }
-//                             }
-//                         }
-//                     }
-//                 }
-//             }
-//         }
-//     }
-// }
-
-pub fn logVirtInfo(virt: usize) void {
-    log.err("logVirtInfo: Virtual Adddress to check: 0x{x}", .{virt});
-
-    const vaddr_info = recLowestEntryFromVirtInfo(virt) catch |err| {
-        log.err("logVirtInfo: Call function recLowestEntryFromVirtInfo: 0x{x} -> error: {}", .{ virt, err });
-        return;
-    };
-
-    log.debug("Paging Table:  0x{x} -> {any}", .{ virt, vaddr_info });
-    const phys_by_rec = recPhysFromVirt(virt) catch |err| {
-        log.err("logVirtInfo: Call function recPhysFromVirt: 0x{x} -> error: {}", .{ virt, err });
-        return;
-    };
-    log.debug("logVirtInfo: Call function recPhyFromVirt: virt: 0x{x} -> 0x{x}\n", .{ virt, phys_by_rec });
-}
-
-// Variables
-var pml4t: []Pml4e = undefined;
-var pat: PAT = undefined;
-
-pub fn init() !void {
-    log.debug("Initializing...", .{});
-    defer log.debug("Initialized", .{});
-
-    if (hhdm_request.response) |hhdm_response| {
-        hhdm_offset = hhdm_response.offset;
-        log.debug("HHDM offset: 0x{x}", .{hhdm_offset});
-        if (hhdm_offset != 0xFFFF_8000_0000_0000) @panic("Invalid HHDM offset");
-    } else @panic("No HHDM bootloader response available");
-
-    if (paging_mode_request.response) |paging_mode_response| {
-        switch (paging_mode_response.mode) {
-            .four_level => {
-                log.info("4-level paging enabled", .{});
-            },
-            .five_level => {
-                log.info("5-level paging enabled", .{});
-                @panic("5-level paging not supported yet");
-            },
-        }
-    } else @panic("No paging mode bootloader response available");
-
-    // setup PAT
-    pat = PAT{};
-    pat.write(); //set default values
-    pat.read(); //read values to be sure we set it right
-    log.debug("The 0x277 MSR register value after the change: 0x{}", .{pat});
-
-    pml4t, const cr3_formatted = Pml4TableFromCr3();
-    log.debug("PML4 table: {*}, cr3_formated: {}", .{ pml4t.ptr, cr3_formatted });
-
-    // Get ready for recursive paging
-    pml4t[510] = .{ .present = true, .writable = true, .aligned_address_4kbytes = @truncate(cr3_formatted.aligned_address_4kbytes) };
-
-    //const lvl4e = retrieveEntryFromVaddr(Pml4e, .four_level, default_page_size, .lvl4, 0xffff_8000_fe80_0000);
-    log.warn("cr3 -> 0x{x}", .{cpu.cr3()});
-    //log.warn("pml4 ptr -> {*}\n\n", .{pml4t.ptr});
-    //
-    //const vaddr_test = 0xffff_8000_fe80_0000;
-    // const vaddr_test = 0xffff800040132000;
-    // const pidx = indexFromVaddr(vaddr_test);
-    // log.warn("pidx: 0x{x} -> {}", .{ vaddr_test, pidx });
-    // const vaddr_test_info = try recLowestEntryFromVirtInfo(vaddr_test);
-    // log.warn("pde:  0x{x} -> {any}", .{ vaddr_test, vaddr_test_info });
-    // if (vaddr_test_info.entry_ptr == null) {
-    //     log.err("Entry not found for vaddr: 0x{x}", .{vaddr_test});
-    // }
-    // const spec_entry: *Pde2MByte = @ptrCast(vaddr_test_info.entry_ptr);
-    // log.warn("entry of {any}, val={!}\n\n", .{ @TypeOf(spec_entry), spec_entry });
-    // const pte = entryFromVaddr(.pt, vaddr_test);
-    // log.warn("pte: -> {any}, pfn= {*}\n\n", .{ pte.*, pte.retrieveFrame().?.ptr });
-    //
-    //
-    // const phys_pci = try physFromVirtInfo(0xffff_8000_fe80_0000);
-    // log.warn("phys_pci: 0x{any}", .{phys_pci});
-    // log.warn("phys_pci_virt: 0x{x}", .{phys_pci.phys});
-    //
-    // const phys_buddy = try physFromVirtInfo(0xffff80001010a000);
-    // log.warn("phys_buddy: 0x{any}", .{phys_buddy});
-    // log.warn("phys_buddy_virt: 0x{x}", .{phys_buddy.phys});
-
-    // wite loop to iterate over each element of address in the table
-    // we use the fact that limine uses identity mapping and at the same time for the same phys addres HHDM
-    const vt = [_]usize{
-        hhdmVirtFromPhys(0x4d00), //HHDM
-        hhdmVirtFromPhys(0x10_0000),
-        hhdmVirtFromPhys(0x7fa61000),
-        hhdmVirtFromPhys(0x7fa63000),
-        hhdmVirtFromPhys(0xfee0_0000),
-    };
-    for (vt) |vaddr| {
-        logVirtInfo(vaddr);
-
-        // log.err("Virtual Adddress to check: 0x{x}", .{vaddr});
-
-        // const vaddr_info = try recLowestEntryFromVirtInfo(vaddr);
-        // log.err("Paging Table:  0x{x} -> {any}", .{ vaddr, vaddr_info });
-        // const phys_by_rec = recPhysFromVirt(vaddr) catch |err| {
-        //     log.err("Call function recPhysFromVirtvirt: 0x{x} -> error: {}", .{ vaddr, err });
-        //     continue;
-        // };
-        // log.err("Call function recPhyFromVirt: vaddr: 0x{x} -> 0x{x}\n", .{ vaddr, phys_by_rec });
-
-        // const vaddr_info = try lowestEntryFromVirtInfo(vaddr);
-        // log.err("Paging Table:  0x{x} -> {any}", .{ vaddr, vaddr_info });
-        // const phys_rec = physFromVirt(vaddr) catch |err| {
-        //     log.err("Call function physFromVirtvirt: 0x{x} -> error: {}", .{ vaddr, err });
-        //     continue;
-        // };
-        //log.err("Call function phyFromVirt: vaddr: 0x{x} -> 0x{x}", .{ vaddr, phys_rec });
-    }
-
-    //   log.info("Find phys 0xfee0_0000", .{});
-    //   findPhys(0xfee0_0000);
-
-    //
-    //
-    //
-    // // const pidx511: Index = .{ .pml4_idx = 511, .pdpt_idx = 511, .pd_idx = 0, .pt_idx = 0, .offset = 0 };
-    // // //const vaddr511 = 0xffff_ffff_ffff_f000;
-    // // const vaddr511 = vaddrFromIndex(pidx511);
-    // // //const pidx511 = pagingIndexFromVaddr(vaddr511);
-    // // log.warn("pidx511 -> {}", .{pidx511});
-    // // const pml4e511 = entryFromVaddr(.pml4, vaddr511);
-    // // log.warn("pml4e511: -> {}, vaddr=0x{x}, ptr={*}, ptr.table={*}, aligned_addres=0x{x}", .{ pml4e511.*, vaddr511, pml4e511, pml4e511.retrieveTable().?, pml4e511.aligned_address_4kbytes });
-    // //
-    // // const pidx510: Index = .{ .pml4_idx = 510, .pdpt_idx = 510, .pd_idx = 510, .pt_idx = 510, .offset = 0 };
-    // // const vaddr510 = vaddrFromIndex(pidx510);
-    // // log.warn("pidx510 -> {}", .{pidx510});
-    // // const pml4e510 = entryFromVaddr(.pml4, vaddr510);
-    // // log.warn("pml4e510: -> {}, ptr={*}", .{ pml4e510.*, pml4e510 });
-    // //
-    // // log.warn("cr4: 0b{b:0>64}", .{@as(u64, cpu.cr4())});
-    // // log.warn("cr3: 0b{b:0>64}", .{@as(u64, cpu.cr3())});
-    // //
-    // // log.warn("pt:     0xFFFFFF00_00000000->0xFFFFFF7F_FFFFFFFF: {}->{}, diff: 0x{x}", .{ indexFromVaddr(0xFFFFFF00_00000000), indexFromVaddr(0xFFFFFF7F_FFFFFFFF), (0xFFFFFF7F_FFFFFFFF - 0xFFFFFF00_00000000) });
-    // // const x = indexFromVaddr(0xFFFFFF7F_8000000);
-    // // _ = &x;
-    // // log.warn("\n\npt:    0xFFFF_FF7F8_000_0000->0xFFFFFF7F_BFFFFFFF : {}->{}, diff: 0x{x}", .{ indexFromVaddr(0xffff_ff7f_8000_0000), indexFromVaddr(0xFFFFFF7F_BFFFFFFF), (0xFFFFFF7F_BFFFFFFF - 0xFFFFFF7F_8000000) });
-    // // log.warn("pdpt: 0xFFFFFF7F_BFC00000->0xFFFFFF7F_BFDFFFFF  : {}->{}, diff: 0x{x}", .{ indexFromVaddr(0xFFFFFF7F_BFC00000), indexFromVaddr(0xFFFFFF7F_BFDFFFFF), (0xFFFFFF7F_BFDFFFFF - 0xFFFFFF7F_BFC00000) });
-    // // log.warn("pml4: 0xFFFFFF7F_BFDFE000 ->0xFFFFFF7F_BFDFEFFF   : {}->{}, diff:0x{x}", .{ indexFromVaddr(0xFFFFFF7F_BFDFE000), indexFromVaddr(0xFFFFFF7F_BFDFEFFF), (0xFFFFFF7F_BFDFEFFF - 0xFFFFFF7F_BFDFE000) });
-    // // log.warn("pml4: 0xFFFFFF7F_BFDFE000 ->0xFFFFFF7F_BFDFEFFF   : {}->{}, diff:0x{x}", .{ indexFromVaddr(0xFFFFFF7F_BFDFE000), indexFromVaddr(0xFFFFFF7F_BFDFEFFF), (0xFFFFFF7F_BFDFEFFF - 0xFFFFFF7F_BFDFE000) });
-    // //
-    // // log.warn("\n\nkernel: {}->{}", .{ indexFromVaddr(0xffffff7f80000000), indexFromVaddr(0xffffff7f8009cb88) });
-    // //
-    // // const vmm_pml4_2 = tableFromVaddr(.pml4, 0xFFFFFF7F_BFDFFFFF) orelse @panic("Table not found");
-    // // log.warn("vmm_pml4_2: 0xFFFFFF7F_BFDFE008 : {*}, len={d}, [0]={}@{*}, [511]={}@{*}", .{ vmm_pml4_2.ptr, vmm_pml4_2.len, vmm_pml4_2[0], &vmm_pml4_2[0], vmm_pml4_2[511], &vmm_pml4_2[511] });
-    // //
-    // // const vmm_pml4 = tableFromVaddr(.pml4, 0xFFFFFF7F_BFC00000) orelse @panic("Table not found [2a]");
-    // // log.warn("vmm_pml4: 0xFFFFFF7F_BFC00000 : {*}, len={d}, [0]={}@{*}, [511]={}@{*}", .{ vmm_pml4.ptr, vmm_pml4.len, vmm_pml4[0], &vmm_pml4[0], vmm_pml4[511], &vmm_pml4[511] });
-    // //
-    // // const vmm_pdpt = tableFromVaddr(.pdpt, 0xFFFFFF7F_BFC00000) orelse @panic("Table not found [2b]");
-    // // log.warn("vmm_pdpt: 0xFFFFFF7F_BFC00000 : {*}, len={d}, [0]={}@{*}, [511]={}@{*}", .{ vmm_pdpt.ptr, vmm_pdpt.len, vmm_pdpt[0], &vmm_pdpt[0], vmm_pdpt[511], &vmm_pdpt[511] });
-    // //
-    // // // recursive in 510, not 511 cause limine occupies it
-    // // log.warn("cr3_formatted: {0}, {0b:0>40}, 0x{0x}", .{cr3_formatted.aligned_address_4kbytes});
-    // // pml4t[510] = .{ .present = true, .writable = true, .aligned_address_4kbytes = @truncate(cr3_formatted.aligned_address_4kbytes) }; //we ignore the last bit
-    // // cpu.invlpg(@intFromPtr(&pml4t[510]));
-    // // log.err("&pml4[510]={*}", .{&pml4t[510]});
-    // //
-    // // //Dla PDPT
-    // // // const pdpt_pidx = .{ .pml4_idx = 510, .pdpt_idx = 510, .pd_idx = 0, .pt_idx = 0, .offset = 0 };
-    // // //  const pdpt510 = entryFromVaddr(.pdpt, vaddrFromIndex(pdpt_pidx));
-    // // //  pdpt510.* = .{ .present = true, .writable = true, .aligned_address_4kbytes = @truncate(cr3_formatted.aligned_address_4kbytes) };
-    // //
-    // // //Dla PD
-    // // // const pd_pidx = .{ .pml4_idx = 510, .pdpt_idx = 510, .pd_idx = 510, .pt_idx = 0, .offset = 0 };
-    // // // const pd510 = entryFromVaddr(.pd, vaddrFromIndex(pd_pidx));
-    // // // pd510.* = .{ .present = true, .writable = true, .aligned_address_4kbytes = @truncate(pdpt510.aligned_address_4kbytes) };
-    // //
-    // // // Dla PT
-    // // // const pt_pidx = .{ .pml4_idx = 510, .pdpt_idx = 0, .pd_idx = 0, .pt_idx = 0, .offset = 0 };
-    // // // const pt510 = entryFromVaddr(.pt, vaddrFromIndex(pt_pidx));
-    // // // pt510.* = .{ .present = true, .writable = true, .aligned_address_4kbytes = @truncate(pd510.aligned_address_4kbytes) };
-    // //
-    // // // const pidx510: Index = .{ .pml4_idx = 510, .pdpt_idx = 0, .pd_idx = 0, .pt_idx = 0 , .offset = 0 };
-    // // // const vaddr510 = vaddrFromIndex(pidx510);
-    // // // log.warn("pidx510 -> {}", .{pidx510});
-    // // // const pml4e510 = entryFromVaddr(.pml4, vaddr510);
-    // // // log.warn("pml4e510: -> {}, ptr={*}", .{ pml4e510.*, pml4e510 });
-    // //
-    //print_tlb();
-    // //
-    // // // const tphys = physFromVirt(0xFFFFFF7F_8000000);
-    // // // log.warn("tphys: 0x{x}", .{tphys});
-
 }

--- a/src/core/paging.zig
+++ b/src/core/paging.zig
@@ -8,5 +8,6 @@ pub usingnamespace switch (builtin.cpu.arch) {
 // addons
 
 pub fn physFromPtr(ptr: anytype) !usize {
-    return try @This().recPhysFromVirt(@intFromPtr(ptr));
+    //return try @This().recPhysFromVirt(@intFromPtr(ptr));
+    return @This().physFromVirt(@intFromPtr(ptr));
 }

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -115,11 +115,20 @@ fn _start() callconv(.C) noreturn {
     //     @panic("ACPI initialization error");
     // };
 
+    // Initialize the memory managment subsystem
     pmm.init() catch |err| {
         log.err("PMM initialization error: {}", .{err});
         @panic("PMM initialization error");
     };
     defer pmm.deinit(); //TODO not here
+
+    // Remap the page tables from Limine memory to the new kernel address space
+    var paging_arena_allocator = std.heap.ArenaAllocator.init(heap.page_allocator);
+    defer paging_arena_allocator.deinit();
+    paging.remapPageTables(paging.default_page_size, paging_arena_allocator.allocator()) catch |err| {
+        log.err("Paging remap error: {}", .{err});
+        @panic("Paging remap error");
+    };
 
     const tm = taskmgmt.new(heap.page_allocator) catch |err| {
         log.err("TSS initialization error: {}", .{err});
@@ -127,6 +136,10 @@ fn _start() callconv(.C) noreturn {
     };
     defer tm.destroy();
     tm.init();
+
+    //{pg
+    paging.logVirtInfo(@intFromPtr(tm));
+    //pg}
 
     const allocator = heap.page_allocator;
     const memory = allocator.alloc(u8, 0x3000) catch |err| {

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -123,12 +123,12 @@ fn _start() callconv(.C) noreturn {
     defer pmm.deinit(); //TODO not here
 
     // Remap the page tables from Limine memory to the new kernel address space
-    // var paging_arena_allocator = std.heap.ArenaAllocator.init(heap.page_allocator);
-    // defer paging_arena_allocator.deinit();
-    // paging.remapPageTables(paging.default_page_size, paging_arena_allocator.allocator()) catch |err| {
-    //     log.err("Paging remap error: {}", .{err});
-    //     @panic("Paging remap error");
-    // };
+    var paging_arena_allocator = std.heap.ArenaAllocator.init(heap.page_allocator);
+    defer paging_arena_allocator.deinit();
+    paging.downmapPageTables(paging.default_page_size, paging_arena_allocator.allocator()) catch |err| {
+        log.err("Downmapping pages error: {}", .{err});
+        @panic("Downmapping pages error");
+    };
 
     const tm = taskmgmt.new(heap.page_allocator) catch |err| {
         log.err("TSS initialization error: {}", .{err});

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -124,11 +124,14 @@ fn _start() callconv(.C) noreturn {
 
     // Remap the page tables from Limine memory to the new kernel address space
     var paging_arena_allocator = std.heap.ArenaAllocator.init(heap.page_allocator);
-    defer paging_arena_allocator.deinit();
+    // TODO: uncomment this when downmapping is ready
+    //defer paging_arena_allocator.deinit();
     paging.downmapPageTables(paging.default_page_size, paging_arena_allocator.allocator()) catch |err| {
         log.err("Downmapping pages error: {}", .{err});
         @panic("Downmapping pages error");
     };
+    //TODO: tbd when downmapping is ready
+    paging_arena_allocator.deinit(); //free the arena allocator after not read downmapping
 
     const tm = taskmgmt.new(heap.page_allocator) catch |err| {
         log.err("TSS initialization error: {}", .{err});

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -124,14 +124,11 @@ fn _start() callconv(.C) noreturn {
 
     // Remap the page tables from Limine memory to the new kernel address space
     var paging_arena_allocator = std.heap.ArenaAllocator.init(heap.page_allocator);
-    // TODO: uncomment this when downmapping is ready
-    //defer paging_arena_allocator.deinit();
+    defer paging_arena_allocator.deinit();
     paging.downmapPageTables(paging.default_page_size, paging_arena_allocator.allocator()) catch |err| {
         log.err("Downmapping pages error: {}", .{err});
         @panic("Downmapping pages error");
     };
-    //TODO: tbd when downmapping is ready
-    paging_arena_allocator.deinit(); //free the arena allocator after not read downmapping
 
     const tm = taskmgmt.new(heap.page_allocator) catch |err| {
         log.err("TSS initialization error: {}", .{err});

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -123,12 +123,12 @@ fn _start() callconv(.C) noreturn {
     defer pmm.deinit(); //TODO not here
 
     // Remap the page tables from Limine memory to the new kernel address space
-    var paging_arena_allocator = std.heap.ArenaAllocator.init(heap.page_allocator);
-    defer paging_arena_allocator.deinit();
-    paging.remapPageTables(paging.default_page_size, paging_arena_allocator.allocator()) catch |err| {
-        log.err("Paging remap error: {}", .{err});
-        @panic("Paging remap error");
-    };
+    // var paging_arena_allocator = std.heap.ArenaAllocator.init(heap.page_allocator);
+    // defer paging_arena_allocator.deinit();
+    // paging.remapPageTables(paging.default_page_size, paging_arena_allocator.allocator()) catch |err| {
+    //     log.err("Paging remap error: {}", .{err});
+    //     @panic("Paging remap error");
+    // };
 
     const tm = taskmgmt.new(heap.page_allocator) catch |err| {
         log.err("TSS initialization error: {}", .{err});

--- a/src/mem/pmm.zig
+++ b/src/mem/pmm.zig
@@ -70,7 +70,7 @@ pub fn init() !void {
         }
 
         if (best_region) |p_region| {
-            const v_region = @as([*]u8, @ptrFromInt(paging.virtFromMME(@intFromPtr(p_region.ptr))))[0..p_region.len];
+            const v_region = @as([*]u8, @ptrFromInt(paging.hhdmVirtFromPhys(@intFromPtr(p_region.ptr))))[0..p_region.len];
             log.debug("init(): Best physical region address: 0x{x} -> 0x{x}, constituting virtual region address: 0x{x} -> 0x{x}", .{
                 @intFromPtr(p_region.ptr),
                 @intFromPtr(p_region.ptr) + p_region.len,
@@ -126,7 +126,7 @@ pub fn init() !void {
 /// We register at leat one zone per region
 fn registerRegionZone(base: usize, len: usize) !void {
     if (len <= min_region_size_pow2) return;
-    const v_region = @as([*]u8, @ptrFromInt(paging.virtFromMME(base)))[0..len];
+    const v_region = @as([*]u8, @ptrFromInt(paging.hhdmVirtFromPhys(base)))[0..len];
     log.debug("registerRegionZone(): Inserting region zone: 0x{x} -> 0x{x}", .{ @intFromPtr(v_region.ptr), @intFromPtr(v_region.ptr) + v_region.len });
     const zone_buddy_allocator = try BuddyAllocatorPreconfigured.init(v_region);
     _ = try avl_tree_by_size.insert(len, zone_buddy_allocator);

--- a/src/modules/block/nvme/NvmeDriver.zig
+++ b/src/modules/block/nvme/NvmeDriver.zig
@@ -130,7 +130,7 @@ pub fn setup(ctx: *anyopaque, allocator: std.mem.Allocator, bus: *Bus, address: 
     Pcie.writeRegisterWithArgs(u16, .command, addr, command | 0b110);
 
     const virt = switch (ctrl.bar.address) {
-        inline else => |phys| paging.virtFromMME(phys),
+        inline else => |phys| paging.hhdmVirtFromPhys(phys),
     };
 
     // Adjust if needed page PAT to write-through
@@ -144,7 +144,7 @@ pub fn setup(ctx: *anyopaque, allocator: std.mem.Allocator, bus: *Bus, address: 
         log.err("Failed to adjust page area PAT for NVMe BAR: {}", .{err});
         return;
     };
-    paging.debugLowestEntryFromVirt(virt); //to be commented out
+    paging.logLowestEntryFromVirt(virt); //to be commented out
     // End of adjustment
 
     // dumpRegisters(ctrl); //TODO: Uncomment this if needed
@@ -706,7 +706,7 @@ fn identifyController(ctrl: *NvmeController) !void {
 /// logRegisters logs the content of the NVMe register set directly using the pointer to the register set
 fn dumpRegisters(ctrl: *const NvmeController) void {
     const virt = switch (ctrl.bar.address) {
-        inline else => |phys| paging.virtFromMME(phys),
+        inline else => |phys| paging.hhdmVirtFromPhys(phys),
     };
 
     const cap_reg_ptr: *volatile u64 = @ptrFromInt(virt);

--- a/src/modules/block/nvme/registers.zig
+++ b/src/modules/block/nvme/registers.zig
@@ -7,13 +7,13 @@ const log = std.log.scoped(.drivers_nvme);
 
 pub fn readRegister(T: type, bar: Pcie.Bar, register_set_field: @TypeOf(.enum_literal)) T {
     return switch (bar.address) {
-        inline else => |addr| @as(*volatile T, @ptrFromInt(paging.virtFromMME(addr) + @offsetOf(RegisterSet, @tagName(register_set_field)))).*,
+        inline else => |addr| @as(*volatile T, @ptrFromInt(paging.hhdmVirtFromPhys(addr) + @offsetOf(RegisterSet, @tagName(register_set_field)))).*,
     };
 }
 
 pub fn writeRegister(T: type, bar: Pcie.Bar, register_set_field: @TypeOf(.enum_literal), value: T) void {
     switch (bar.address) {
-        inline else => |addr| @as(*volatile T, @ptrFromInt(paging.virtFromMME(addr) + @offsetOf(RegisterSet, @tagName(register_set_field)))).* = value,
+        inline else => |addr| @as(*volatile T, @ptrFromInt(paging.hhdmVirtFromPhys(addr) + @offsetOf(RegisterSet, @tagName(register_set_field)))).* = value,
     }
 }
 


### PR DESCRIPTION
Changes:
- Refactored x86_64/paging.zig
- Enhanced x86_64/cpu.zig with CR3 and CR4 management routines
- Added PCID support in paging logic
- Added downmapping code (2MB → 4KB)
- Remapped Limine pages
- QEMU now works with KVM enabled

Rationale:
Limine manages paging in its own manner, utilizing 2MB and 4KB pages for its operations. To ensure a unified 4KB page size across the kernel, this PR introduces a downmapping mechanism to fully remap page tables into the kernel's own memory space.

The code retains the PML4 entries (used by Limine), as Limine remains in use until late in the kernel initialization process (e.g., for framebuffer operations). This ensures compatibility while transitioning to the kernel's custom paging implementation.